### PR TITLE
Added use of user-defined devices aliases

### DIFF
--- a/router.py
+++ b/router.py
@@ -534,18 +534,17 @@ class ClientDevInfo:
         """Update connected device info."""
         now: datetime = dt_util.utcnow()
         if dev_info:
-            if not self._name:
-                # Prefer the user-defined alias as a name
-                alias = dev_info.get("alias")
-                if alias and alias.strip():
-                    self._name = alias
+            # Prefer the user-defined alias as a name
+            alias = dev_info.get("alias")
+            if alias and alias.strip():
+                self._name = alias
+            else:
+                # If no alias, fallback to auto-assigned name field
+                name = dev_info.get("name", "")
+                if name == "*" or not name.strip():
+                    self._name = self._mac.replace(":", "_")
                 else:
-                    # If no alias, fallback to auto-assigned name field
-                    name = dev_info.get("name", "")
-                    if name == "*" or not name.strip():
-                        self._name = self._mac.replace(":", "_")
-                    else:
-                        self._name = name
+                    self._name = name
             self._ip_address = dev_info["ip"]
             self._last_activity = now
             self._connected = dev_info["online"]

--- a/router.py
+++ b/router.py
@@ -313,8 +313,8 @@ class GLinetRouter:
             if device_mac in self._devices:
                 continue
 
-            alias = dev_info.get("alias", "").strip()
-            name = dev_info.get("name", "").strip()
+            alias = dev_info.get("alias").strip()
+            name = dev_info.get("name").strip()
             # Skip if both alias and name are empty
             if not alias and not name:
                 continue

--- a/router.py
+++ b/router.py
@@ -313,8 +313,8 @@ class GLinetRouter:
             if device_mac in self._devices:
                 continue
 
-            alias = dev_info.get("alias").strip()
-            name = dev_info.get("name").strip()
+            alias = dev_info.get("alias","").strip()
+            name = dev_info.get("name","").strip()
             # Skip if both alias and name are empty
             if not alias and not name:
                 continue

--- a/router.py
+++ b/router.py
@@ -108,8 +108,6 @@ class GLinetRouter:
                 self._api.router_info
             )  # TODO seems to always throw unexpected err on first boot
             _LOGGER.debug("Router info retrieved: %s", router_info)
-
-
             self._model = router_info["model"]
             self._sw_v = router_info["firmware_version"]
             self._factory_mac = router_info["mac"]


### PR DESCRIPTION
Hey,

Some very minor changes to prioritise the 'alias' field instead of 'name'. That way if the user renames the devices from the GL.iNet interface, these will be the names that are picked and not the auto-generated names.

As an added bonus, this allows tracking devices that don't report a name, if the user sets one in the GL.iNet interface, and that also allows tracking devices with dynamic MAC addresses assuming they always pick the same for this particular SSID (which is usually the case)