### PR TITLE
Centralise DeviceInfo

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,5 +22,5 @@ jobs:
       # Over time, bring into line with https://github.com/home-assistant/core/blob/4be2e84ce65de68883f16770818cf2e354cd6cc7/pyproject.toml#L276
       # At the moment we are disabling fix-me
       run: |
-        pylint --disable=import-error,duplicate-code,fixme,line-too-long,invalid-name,too-many-public-methods,abstract-method,overridden-final-method,too-many-instance-attributes,too-many-public-methods,too-few-public-methods,too-many-branches $(git ls-files '*.py')
+        pylint --disable=import-error,fixme,line-too-long,invalid-name,too-many-public-methods,abstract-method,overridden-final-method,too-many-instance-attributes,too-many-public-methods,too-few-public-methods,too-many-branches $(git ls-files '*.py')
 

--- a/button.py
+++ b/button.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DATA_GLINET, DOMAIN
@@ -36,6 +33,7 @@ class RebootButton(ButtonEntity):
     def __init__(self, router: GLinetRouter) -> None:
         """Initialize a GLinet device."""
         self._router = router
+        self._attr_device_info = router.device_info
 
     _attr_icon = "mdi:restart"
     _attr_has_entity_name = True
@@ -58,13 +56,3 @@ class RebootButton(ButtonEntity):
     def entity_category(self) -> EntityCategory:
         """A config entity."""
         return EntityCategory.CONFIG
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        # TODO this should probably be defined in the router device not here in the switch
-        data: DeviceInfo = {
-            "connections": {(CONNECTION_NETWORK_MAC, self._router.factory_mac)},
-            "identifiers": {(DOMAIN, self._router.factory_mac)},
-        }
-        return data

--- a/router.py
+++ b/router.py
@@ -24,6 +24,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
@@ -425,17 +426,19 @@ class GLinetRouter:
             sw_version=self._sw_v,
         )
 
-    # @property
-    # def device_info(self) -> DeviceInfo:
-    #     """Return the device information."""
-    #     data: DeviceInfo = {
-    #       "connections": {(CONNECTION_NETWORK_MAC, self.factory_mac)},
-    #       "identifiers": {(DOMAIN, self.factory_mac)},
-    #       "name": self.name,
-    #       "model": self.model,
-    #       "manufacturer": "GL-inet",
-    #     }
-    #     return data
+    # TODO this doesn't seem to do anything yet
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.unique_id or self.factory_mac)},
+            connections={(CONNECTION_NETWORK_MAC, self.factory_mac)},
+            name=self.name,
+            model=self.model or "GL-inet Router",
+            manufacturer="GL-inet",
+            configuration_url=f"http://{self.host}",
+        )
 
     @property
     def signal_device_new(self) -> str:
@@ -451,6 +454,11 @@ class GLinetRouter:
     def host(self) -> str:
         """Return router host."""
         return self._host
+
+    @property
+    def unique_id(self) -> str:
+        """Return router unique id."""
+        return self._entry.unique_id or self._entry.entry_id
 
     @property
     def devices(self) -> dict[str, ClientDevInfo]:

--- a/router.py
+++ b/router.py
@@ -156,11 +156,10 @@ class GLinetRouter:
                     entry.unique_id, entry.original_name
                 )
 
-        # TODO, should we load in the switch entities?
-
         # Each new setup should renew the token
         await self.renew_token()
 
+        # Update device tracker and switch entities
         await self.update_all()
 
         self.add_to_device_registry()
@@ -449,12 +448,12 @@ class GLinetRouter:
     @property
     def signal_device_new(self) -> str:
         """Event specific per GL-inet entry to signal new device."""
-        return f"{DOMAIN}-device-new"
+        return f"{DOMAIN}-device-new-{self._factory_mac}"
 
     @property
     def signal_device_update(self) -> str:
         """Event specific per GL-inet entry to signal updates in devices."""
-        return f"{DOMAIN}-device-update"
+        return f"{DOMAIN}-device-update-{self._factory_mac}"
 
     @property
     def host(self) -> str:

--- a/switch.py
+++ b/switch.py
@@ -8,8 +8,6 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DATA_GLINET, DOMAIN

--- a/switch.py
+++ b/switch.py
@@ -44,6 +44,8 @@ class TailscaleSwitch(SwitchEntity):
     def __init__(self, router: GLinetRouter) -> None:
         """Initialize a GLinet device."""
         self._router = router
+        self._attr_device_info = router.device_info
+
         # self._client = client
 
     _attr_icon = "mdi:vpn"  # TODO would be better to have MDI style icons for each of the VPN types
@@ -101,16 +103,6 @@ class TailscaleSwitch(SwitchEntity):
         """Enabled by default."""
         return self._router.tailscale_configured
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        # TODO this should probably be defined in the router device not here in the switch
-        data: DeviceInfo = {
-            "connections": {(CONNECTION_NETWORK_MAC, self._router.factory_mac)},
-            "identifiers": {(DOMAIN, self._router.factory_mac)},
-        }
-        return data
-
 
 class WireGuardSwitch(SwitchEntity):
     """Representation of a VPN switch."""
@@ -123,6 +115,7 @@ class WireGuardSwitch(SwitchEntity):
         """Initialize a GLinet device."""
         self._router = router
         self._client = client
+        self._attr_device_info = router.device_info
 
     _attr_icon = "mdi:vpn"  # TODO would be better to have MDI style icons for each of the VPN types
 
@@ -167,13 +160,3 @@ class WireGuardSwitch(SwitchEntity):
     def entity_category(self) -> EntityCategory:
         """A config entity."""
         return EntityCategory.CONFIG
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        # TODO this should probably be defined in the router device not here in the switch
-        data: DeviceInfo = {
-            "connections": {(CONNECTION_NETWORK_MAC, self._router.factory_mac)},
-            "identifiers": {(DOMAIN, self._router.factory_mac)},
-        }
-        return data

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,23 @@
+"""Utility functions for GL-inet routers."""
+
+def increment_mac(mac: str, sep: str = ':') -> str:
+    """Increment a MAC address by 1.
+
+    This is helpful because GL-inet devices' LAN ports have a mac of factory_mac + 1
+    but this is not found in the API
+    :param mac: Original MAC address (e.g. "00:1A:2B:3C:4D:5E" or "00-1A-2B-3C-4D-5E").
+    :param sep: Separator to use in the output (default is ':').
+    :return: Incremented MAC address as a string.
+    """
+    # Remove common separators and convert to integer
+    hex_str = mac.replace(sep, '').replace('-', '').lower()
+    value = int(hex_str, 16)
+
+    # Increment and wrap around at 48 bits
+    value = (value + 1) & ((1 << 48) - 1)
+
+    # Format back to hexadecimal, ensuring six bytes (12 hex digits)
+    new_hex = f"{value:012x}"
+
+    # Reinsert the separator every two hex digits
+    return sep.join(new_hex[i:i+2] for i in range(0, 12, 2)).upper()


### PR DESCRIPTION
Fixes #21 

At the moment I haven't confirmed that the scanner entities successfully show up on devices that already exist

https://github.com/HarvsG/core/blob/32da04bda70fbf559dbfcd6b7675a9c61d59e75b/homeassistant/components/device_tracker/config_entry.py#L355-L356

[def find_device_entry(self) -> dr.DeviceEntry | None:](https://github.com/HarvsG/core/blob/32da04bda70fbf559dbfcd6b7675a9c61d59e75b/homeassistant/components/device_tracker/config_entry.py#L391)

[async def async_internal_added_to_hass(self) -> None:](https://github.com/HarvsG/core/blob/32da04bda70fbf559dbfcd6b7675a9c61d59e75b/homeassistant/components/device_tracker/config_entry.py#L399)