### PR TITLE
Add missing network interface types

### DIFF
--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -58,6 +58,11 @@ class DeviceInterfaceType(StrEnum):
     UNKNOWN = "Unknown"
     DONGLE = "Dongle"
     BYPASS_ROUTE = "Bypass Route"
+    UNKNOWN2 = "Unknown2"
+    MLO = "MLO"
+    MLO_GUEST = "MLO Guest"
+    WIFI_6 = "6GHz"
+    WIFI_6_GUEST = "6GHz Guest"
 
 
 class GLinetRouter:


### PR DESCRIPTION
Fixes the integration not being able to boot if any devices use WiFi 6Ghz (guest included), or MLO (Guest included). There's still an unknown 8th type which I could not find.