### PR TITLE
Treat buffers and cache as free memory in memory free calculation

### DIFF
--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -107,7 +107,7 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda system_status: (
             (memory_total := system_status.get("memory_total", 0)) > 0
-            and (memory_free := system_status.get("memory_free", 0)) >= 0
+            and (memory_free := system_status.get("memory_free", 0) + system_status.get("memory_buff_cache", 0)) >= 0
             and (mu := 100 * (1 - memory_free / memory_total))
             and isinstance(mu, float)
             and 0 <= mu <= 100

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -117,6 +117,13 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         extra_attributes_fn=lambda system_status: {
             "memory_total": system_status.get("memory_total"),
             "memory_free": system_status.get("memory_free"),
+            "memory_buff_cache": system_status.get("memory_buff_cache"),
+            "memory_available": system_status.get("memory_buff_cache") + system_status.get("memory_free"),
+            "memory_used": (
+                system_status.get("memory_total")
+                - system_status.get("memory_buff_cache")
+                - system_status.get("memory_free")
+            ),
         },
     ),
     SystemStatusEntityDescription(


### PR DESCRIPTION
Treat memory_buff_cache as free memory rather than used memory. It's not totally wrong to do this, since you can evict a lot of that with `echo 3 > /proc/sys/vm/drop_caches` and see an immediate drop in `top`, but the RPC API really should be more detailed.

Tested on Slate AXT-1800... guess when I restarted HomeAssistant to pick up the change.

<img width="575" height="517" alt="Screenshot_2026-02-19_11-00-52" src="https://github.com/user-attachments/assets/4d0d7f02-9617-4575-998e-4aecd0270bdd" />


Fixes HarvsG/ha-glinet4-integration#85