### PR TITLE
Add WAN status sensors

### DIFF
--- a/custom_components/glinet/__init__.py
+++ b/custom_components/glinet/__init__.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .router import GLinetRouter
-
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+    from .router import GLinetRouter
 
 PLATFORMS = ["button", "device_tracker", "sensor", "switch"]
 
@@ -19,8 +19,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     Called by home assistant on initial config, restart and
     component reload.
     """
+    # Lazy import keeps the package init free of HA/gli4py at module load
+    # time, so unit tests for pure helpers in `wan.py` can run without the
+    # full integration dependency tree.
+    from .router import GLinetRouter  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
 
-    # Store an API object for platforms to access
     router = GLinetRouter(hass, entry)
     await router.setup()
 

--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -36,6 +36,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import API_PATH, DOMAIN
 from .utils import adjust_mac
+from .wan import WanInterfaceState, parse_network_array
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -107,6 +108,9 @@ class GLinetRouter:
         self._wireguard_connections: list[WireGuardClient] | None = None
         self._tailscale_config: dict = {}
         self._tailscale_connection: bool | None = None
+        self._wan_status: dict[str, WanInterfaceState] = {}
+        self._known_wan_interfaces: set[str] = set()
+        self._warned_wan_interfaces: set[str] = set()
 
         # Flow control
         self._late_init_complete: bool = False
@@ -316,12 +320,40 @@ class GLinetRouter:
         return response
 
     async def update_system_status(self) -> None:
-        """Update the system status from the API."""
+        """Update the system status and per-WAN connectivity from the API.
+
+        Pulls both the ``system`` and ``network`` fields out of one call. If
+        the call fails, last-known WAN state is preserved (we do NOT reset
+        to empty), so a transient API hiccup does not flap every WAN sensor
+        to ``disconnected`` for a single cycle.
+        """
 
         status = await self._update_platform(self._api.router_get_status)
-        # For now only the content of the `system` field seems of use
-        if status:
-            self._system_status = status.get("system", {})
+        if not status:
+            return
+        self._system_status = status.get("system", {})
+        result = parse_network_array(status.get("network", []))
+        self._wan_status = result.states
+
+        for iface in result.malformed_interfaces:
+            if iface not in self._warned_wan_interfaces:
+                _LOGGER.warning(
+                    "GL-iNet router %s returned a malformed entry for WAN interface %s; "
+                    "missing up/online field defaulted to False",
+                    self._host,
+                    iface,
+                )
+                self._warned_wan_interfaces.add(iface)
+
+        currently_up = {n for n, s in result.states.items() if s.up}
+        new_to_register = currently_up - self._known_wan_interfaces
+        if new_to_register:
+            self._known_wan_interfaces.update(new_to_register)
+            async_dispatcher_send(
+                self.hass, self.signal_wan_new, sorted(new_to_register)
+            )
+
+        async_dispatcher_send(self.hass, self.signal_wan_update)
 
     async def update_device_trackers(self) -> None:
         """Update the device trackers."""
@@ -491,6 +523,16 @@ class GLinetRouter:
         return f"{DOMAIN}-device-update-{self._factory_mac}"
 
     @property
+    def signal_wan_new(self) -> str:
+        """Dispatcher signal: a never-before-seen WAN interface is now up."""
+        return f"{DOMAIN}-wan-new-{self._factory_mac}"
+
+    @property
+    def signal_wan_update(self) -> str:
+        """Dispatcher signal: WAN states have been refreshed (fired every poll)."""
+        return f"{DOMAIN}-wan-update-{self._factory_mac}"
+
+    @property
     def host(self) -> str:
         """Return router host."""
         return self._host
@@ -570,6 +612,20 @@ class GLinetRouter:
         """Property for system status."""
 
         return self._system_status
+
+    @property
+    def wan_status(self) -> dict[str, WanInterfaceState]:
+        """Return the latest WAN interface states keyed by interface name."""
+        return self._wan_status
+
+    def register_known_wan_interfaces(self, interfaces: set[str]) -> None:
+        """Mark interfaces as already-registered so we don't fire ``signal_wan_new`` for them.
+
+        Called by the sensor platform during ``async_setup_entry`` after it
+        has loaded persisted entities from the registry and added entities
+        for any currently-up interfaces.
+        """
+        self._known_wan_interfaces.update(interfaces)
 
 
 @dataclass

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -7,13 +7,19 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
+from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.dt import utcnow
+
+from .wan_sensor import WanStatusSensor
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -144,7 +150,9 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
 
 
 async def async_setup_entry(
-    _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors."""
     _LOGGER.debug("Setting up GL-iNet Sensors")
@@ -175,6 +183,61 @@ async def async_setup_entry(
             sensors.remove(sensor)
 
     async_add_entities(sensors, True)
+
+    # WAN status sensors: load any persisted entities from the registry,
+    # plus an entity per interface currently reporting up. Future "new WAN"
+    # discoveries are picked up via the router's dispatcher signal.
+    await _setup_wan_sensors(hass, entry, router, async_add_entities)
+
+
+async def _setup_wan_sensors(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    router: GLinetRouter,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Register WAN sensors from registry + currently-up interfaces, then subscribe."""
+    entity_registry = er.async_get(hass)
+    registry_entries = er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    )
+
+    wan_unique_id_prefix = f"glinet_sensor/{router.factory_mac}/wan_"
+    persisted_interfaces: set[str] = set()
+    for reg_entry in registry_entries:
+        if reg_entry.domain != SENSOR_DOMAIN:
+            continue
+        if not reg_entry.unique_id.startswith(wan_unique_id_prefix):
+            continue
+        persisted_interfaces.add(reg_entry.unique_id[len(wan_unique_id_prefix):])
+
+    currently_up = {
+        name for name, state in router.wan_status.items() if state.up
+    }
+
+    initial_interfaces = persisted_interfaces | currently_up
+    router.register_known_wan_interfaces(initial_interfaces)
+    if initial_interfaces:
+        async_add_entities(
+            WanStatusSensor(router, iface)
+            for iface in sorted(initial_interfaces)
+        )
+
+    @callback
+    def _handle_new_wan(new_interfaces: list[str]) -> None:
+        """Add entities for newly-discovered up interfaces.
+
+        The router fires ``signal_wan_new`` with the sorted list of names
+        that just transitioned to ``known``. Each name fires exactly once,
+        so we don't need to deduplicate here.
+        """
+        async_add_entities(
+            WanStatusSensor(router, iface) for iface in new_interfaces
+        )
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, router.signal_wan_new, _handle_new_wan)
+    )
 
 
 def _uptime_calculation(seconds_uptime: float, last_value: datetime | None) -> datetime:

--- a/custom_components/glinet/wan.py
+++ b/custom_components/glinet/wan.py
@@ -1,0 +1,111 @@
+"""WAN status helpers for the GL-iNet integration.
+
+Pure helpers (state mapping, friendly names, malformed-input parsing) live
+here so they can be unit-tested without a Home Assistant harness. The
+``WanStatusSensor`` entity class lives in :mod:`wan_sensor`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+STATE_CONNECTED = "connected"
+STATE_FAILING = "failing"
+STATE_DISCONNECTED = "disconnected"
+
+
+def state_for(*, up: bool, online: bool) -> str:
+    """Map link/internet booleans to one of the three WAN states."""
+    if not up:
+        return STATE_DISCONNECTED
+    if not online:
+        return STATE_FAILING
+    return STATE_CONNECTED
+
+
+_FRIENDLY_NAMES: dict[str, str] = {
+    "wan": "Primary WAN",
+    "secondwan": "Secondary WAN",
+    "wan6": "Primary WAN (IPv6)",
+    "secondwan6": "Secondary WAN (IPv6)",
+    "wwan": "WiFi Repeater",
+    "wwan6": "WiFi Repeater (IPv6)",
+    "tethering": "Phone Tether",
+    "tethering6": "Phone Tether (IPv6)",
+}
+
+
+def friendly_name(interface: str) -> str:
+    """Return a UI-friendly label for a raw GL-iNet interface name.
+
+    Multiple USB modems get the raw suffix appended in parentheses so a
+    user with two modems sees two distinct entity names.
+    """
+    if interface in _FRIENDLY_NAMES:
+        return _FRIENDLY_NAMES[interface]
+    if interface.startswith("modem_"):
+        if interface.endswith("_6"):
+            return f"USB Modem IPv6 ({interface})"
+        return f"USB Modem ({interface})"
+    return interface
+
+
+@dataclass(frozen=True)
+class WanInterfaceState:
+    """Latest known state of one WAN interface, as reported by the router."""
+
+    name: str
+    up: bool
+    online: bool
+
+
+@dataclass(frozen=True)
+class ParseResult:
+    """Output of :func:`parse_network_array`.
+
+    ``malformed_interfaces`` is the list of interface names whose entry was
+    missing one or both of the ``up`` / ``online`` fields. Callers should
+    log a one-time warning for each such name.
+    """
+
+    states: dict[str, WanInterfaceState]
+    malformed_interfaces: list[str] = field(default_factory=list)
+
+
+def parse_network_array(raw: object) -> ParseResult:
+    """Parse the ``network`` field of ``router_get_status`` into a state map.
+
+    Pure function — no logging, no side effects. Caller is responsible for
+    logging warnings about ``malformed_interfaces``.
+
+    Behaviour:
+    - Non-list input → empty result.
+    - Entries that are not dicts → silently dropped.
+    - Entries missing a non-empty string ``interface`` → silently dropped.
+    - Entries with a name but missing ``up`` / ``online`` → recorded, the
+      missing field defaults to ``False``, and the name is added to
+      ``malformed_interfaces`` so the caller can warn once.
+    """
+    if not isinstance(raw, list):
+        return ParseResult(states={})
+
+    states: dict[str, WanInterfaceState] = {}
+    malformed: list[str] = []
+
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("interface")
+        if not isinstance(name, str) or not name:
+            continue
+        has_up = "up" in entry
+        has_online = "online" in entry
+        if not (has_up and has_online):
+            malformed.append(name)
+        states[name] = WanInterfaceState(
+            name=name,
+            up=bool(entry.get("up", False)),
+            online=bool(entry.get("online", False)),
+        )
+
+    return ParseResult(states=states, malformed_interfaces=malformed)

--- a/custom_components/glinet/wan_sensor.py
+++ b/custom_components/glinet/wan_sensor.py
@@ -1,0 +1,88 @@
+"""WAN status sensor entity for the GL-iNet integration.
+
+Lives in its own module (separate from the pure helpers in :mod:`wan`) so
+that unit tests for the helpers can run without a Home Assistant harness.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .wan import (
+    STATE_CONNECTED,
+    STATE_DISCONNECTED,
+    STATE_FAILING,
+    friendly_name,
+    state_for,
+)
+
+if TYPE_CHECKING:
+    from .router import GLinetRouter
+
+
+_ICON_FOR_STATE: dict[str, str] = {
+    STATE_CONNECTED: "mdi:lan-connect",
+    STATE_FAILING: "mdi:lan-disconnect",
+    STATE_DISCONNECTED: "mdi:lan-pending",
+}
+
+
+class WanStatusSensor(SensorEntity):
+    """Sensor showing the connectivity state of one WAN interface."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [STATE_CONNECTED, STATE_FAILING, STATE_DISCONNECTED]
+
+    def __init__(self, router: GLinetRouter, interface: str) -> None:
+        """Initialise a WAN status sensor for the given interface name."""
+        self._router = router
+        self._interface = interface
+        self._attr_unique_id = (
+            f"glinet_sensor/{router.factory_mac}/wan_{interface}"
+        )
+        self._attr_name = friendly_name(interface)
+        self._attr_device_info = router.device_info
+
+    @property
+    def native_value(self) -> str:
+        """Return one of ``connected`` / ``failing`` / ``disconnected``."""
+        state = self._router.wan_status.get(self._interface)
+        if state is None:
+            return STATE_DISCONNECTED
+        return state_for(up=state.up, online=state.online)
+
+    @property
+    def icon(self) -> str:
+        """Pick an mdi icon based on the current state."""
+        return _ICON_FOR_STATE[self.native_value]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose raw interface name and link-layer state for automations."""
+        state = self._router.wan_status.get(self._interface)
+        return {
+            "interface": self._interface,
+            "up": state.up if state else False,
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to the router's per-poll WAN-update signal."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_wan_update,
+                self._handle_update,
+            )
+        )
+
+    @callback
+    def _handle_update(self) -> None:
+        """Re-render this entity's state."""
+        self.async_write_ha_state()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for the GL-iNet integration."""

--- a/tests/test_wan.py
+++ b/tests/test_wan.py
@@ -1,0 +1,128 @@
+"""Unit tests for the WAN helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.glinet.wan import (
+    STATE_CONNECTED,
+    STATE_DISCONNECTED,
+    STATE_FAILING,
+    ParseResult,
+    WanInterfaceState,
+    friendly_name,
+    parse_network_array,
+    state_for,
+)
+
+
+@pytest.mark.parametrize(
+    ("up", "online", "expected"),
+    [
+        (True, True, STATE_CONNECTED),
+        (True, False, STATE_FAILING),
+        (False, True, STATE_DISCONNECTED),
+        (False, False, STATE_DISCONNECTED),
+    ],
+)
+def test_state_for_all_combinations(up: bool, online: bool, expected: str) -> None:
+    """`state_for` covers every (up, online) combination."""
+    assert state_for(up=up, online=online) == expected
+
+
+@pytest.mark.parametrize(
+    ("interface", "expected"),
+    [
+        ("wan", "Primary WAN"),
+        ("secondwan", "Secondary WAN"),
+        ("wan6", "Primary WAN (IPv6)"),
+        ("secondwan6", "Secondary WAN (IPv6)"),
+        ("wwan", "WiFi Repeater"),
+        ("wwan6", "WiFi Repeater (IPv6)"),
+        ("tethering", "Phone Tether"),
+        ("tethering6", "Phone Tether (IPv6)"),
+        ("modem_1_1_2", "USB Modem (modem_1_1_2)"),
+        ("modem_1_1_2_6", "USB Modem IPv6 (modem_1_1_2_6)"),
+        ("modem_2_3", "USB Modem (modem_2_3)"),
+        ("future_unknown_iface", "future_unknown_iface"),
+        ("", ""),
+    ],
+)
+def test_friendly_name(interface: str, expected: str) -> None:
+    """Documented mappings + modem disambiguation + raw passthrough."""
+    assert friendly_name(interface) == expected
+
+
+def test_parse_network_array_happy_path() -> None:
+    """Parses the realistic BE9300 payload."""
+    raw = [
+        {"interface": "wan", "online": True, "up": True},
+        {"interface": "secondwan", "online": True, "up": True},
+        {"interface": "wan6", "online": False, "up": False},
+    ]
+    result = parse_network_array(raw)
+    assert result.malformed_interfaces == []
+    assert result.states == {
+        "wan": WanInterfaceState(name="wan", up=True, online=True),
+        "secondwan": WanInterfaceState(name="secondwan", up=True, online=True),
+        "wan6": WanInterfaceState(name="wan6", up=False, online=False),
+    }
+
+
+def test_parse_network_array_link_up_no_internet() -> None:
+    """The 'failing' state is preserved through parsing."""
+    raw = [{"interface": "wan", "online": False, "up": True}]
+    result = parse_network_array(raw)
+    assert result.states["wan"].up is True
+    assert result.states["wan"].online is False
+
+
+def test_parse_network_array_non_list_returns_empty() -> None:
+    """Garbage input is dropped, not exceptions."""
+    for raw in (None, {}, "wan", 42):
+        result = parse_network_array(raw)
+        assert result.states == {}
+        assert isinstance(result, ParseResult)
+
+
+def test_parse_network_array_skips_non_dict_entries() -> None:
+    """Non-dict items in the list are silently dropped."""
+    raw = [None, "wan", 42, {"interface": "wan", "up": True, "online": True}]
+    result = parse_network_array(raw)
+    assert set(result.states.keys()) == {"wan"}
+
+
+def test_parse_network_array_skips_entries_without_interface_name() -> None:
+    """Entry with no name is silently dropped (no name to warn about)."""
+    raw = [
+        {"interface": "wan", "up": True, "online": True},
+        {"online": False, "up": False},  # no interface key
+        {"interface": "", "up": True, "online": True},  # empty name
+        {"interface": 42, "up": True, "online": True},  # non-string
+    ]
+    result = parse_network_array(raw)
+    assert set(result.states.keys()) == {"wan"}
+    assert result.malformed_interfaces == []
+
+
+def test_parse_network_array_defaults_missing_bools_and_warns() -> None:
+    """Entry has a name but missing up/online — defaults to False, flag for warning."""
+    raw = [
+        {"interface": "wan", "up": True, "online": True},
+        {"interface": "secondwan"},  # missing both
+        {"interface": "wan6", "up": True},  # missing online
+    ]
+    result = parse_network_array(raw)
+    assert result.states["secondwan"].up is False
+    assert result.states["secondwan"].online is False
+    assert result.states["wan6"].up is True
+    assert result.states["wan6"].online is False
+    assert sorted(result.malformed_interfaces) == ["secondwan", "wan6"]
+
+
+def test_parse_network_array_coerces_truthy_non_bool() -> None:
+    """Some firmware versions might return 0/1 ints instead of bools."""
+    raw = [{"interface": "wan", "up": 1, "online": 0}]
+    result = parse_network_array(raw)
+    assert result.states["wan"].up is True
+    assert result.states["wan"].online is False


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                               
  Adds a read-only sensor per WAN candidate interface (e.g. `wan`, `secondwan`, `wwan`, `tethering`, `modem_*`) with three states: `connected`, `failing` (link up, no internet reachable), `disconnected`.    
                                                                                                                                                                                                               
  ## What's new                                                                                                                                                                                                
                                                                  
  - Per-WAN sensors using `SensorDeviceClass.ENUM` with options `connected` / `failing` / `disconnected`.                                                                                                      
  - Friendly names mapped from the raw interface names: `wan` → "Primary WAN", `secondwan` → "Secondary WAN", `wwan` → "WiFi Repeater", `tethering` → "Phone Tether", `modem_x_y_z` → "USB Modem
  (modem_x_y_z)", IPv6 variants get an "(IPv6)" suffix. Raw name is exposed as the `interface` attribute for automations/templates.                                                                            
  - Auto-discovery: an interface becomes a sensor once it's been seen `up` at least once, then persists across HA restarts via the entity registry. New interfaces (USB modem plugged in later, etc.) appear 
  without an HA restart.                                                                                                                                                                                       
  - 30 s polling — piggybacks on the existing `router_get_status` call. **Zero new HTTP requests, no `gli4py` changes.**
                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                               
  ## Implementation                                                                                                                                                                                            
                                                                  
  - `custom_components/glinet/wan.py` — pure helpers + dataclasses (state mapping, friendly names, network-array parser). **No HA imports** — unit-testable in isolation.                                      
  - `custom_components/glinet/wan_sensor.py` — `WanStatusSensor` entity class.
  - `custom_components/glinet/router.py` — stops discarding `response["network"]` from `router_get_status` (which was previously thrown away). Adds `wan_status` property, `signal_wan_new` /                  
  `signal_wan_update` dispatcher signals, and `register_known_wan_interfaces()` for platform setup.                                                                                                            
  - `custom_components/glinet/sensor.py` — registers `WanStatusSensor` entities from the entity registry + any currently-up interfaces; subscribes to the new-WAN signal for live discovery.                   
  - `custom_components/glinet/__init__.py` — small refactor: moved `from .router import GLinetRouter` into `async_setup_entry()`. **No production behavior change.** Stops the package init from eagerly       
  loading HA / `gli4py`, which lets unit tests import `wan.py` without those deps installed.                                                                                                                   
                                                                                                                                                                                                               
  ## Tests                                                                                                                                                                                                     
                                                                  
  First unit tests in this repo (partially addresses the "Add tests" README TODO):                                                                                                                             
   
  ```                                                                                                                                                                                                          
  uv run pytest tests/ -v                                         
  # 24 passed
  ```

  Coverage:
  - State mapping for every `(up, online)` combination.
  - Friendly-name mapping for every documented raw name + modem disambiguation + raw passthrough fallback.                                                                                                     
  - Network-array parsing: happy path, link-up-no-internet, non-list garbage, non-dict entries, missing-name skip, missing-fields default-and-warn, non-bool coercion.                                         
                                                                                                                                                                                                                                                                                                                                                                                             
  ## Notes for review                                             
                   
  - **No `manifest.json` version bump** — assumed that's done at release time. Let me know if you'd prefer it bumped here.
  - The `__init__.py` lazy-import refactor has independent value (test isolation, faster cold-start), but I'm happy to revert it if you'd rather keep that file unchanged. 

## Preview in HA:

Notice the `Primary WAN` and `Secondary WAN` with `connected` values in my setup

<img width="383" height="573" alt="Screenshot 2026-04-28 at 21 54 29" src="https://github.com/user-attachments/assets/4dff17cb-408c-4785-b3cc-8b97b094eec4" />

