### PR TITLE
Discover WiFi-interface switches without a reload (#103)

### DIFF
--- a/custom_components/glinet/__init__.py
+++ b/custom_components/glinet/__init__.py
@@ -26,6 +26,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.runtime_data = router
 
+    # Reload when the user changes options so new settings take effect.
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -37,9 +40,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update when config_entry options update."""
-    router: GLinetRouter = entry.runtime_data
-
-    # Currently router.update_options() never returns True
-    if router.update_options(dict(entry.options)):
-        await hass.config_entries.async_reload(entry.entry_id)
+    """Reload the config entry when its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/glinet/config_flow.py
+++ b/custom_components/glinet/config_flow.py
@@ -32,11 +32,16 @@ from homeassistant.helpers.device_registry import format_mac
 from .const import (
     API_PATH,
     CONF_TITLE,
+    CONF_TRACK_RANDOMIZED_MAC,
+    DEFAULT_TRACK_RANDOMIZED_MAC,
     DOMAIN,
     GLINET_DEFAULT_PW,
     GLINET_DEFAULT_URL,
     GLINET_DEFAULT_USERNAME,
     GLINET_FRIENDLY_NAME,
+    TRACK_RANDOMIZED_MAC_DISABLED,
+    TRACK_RANDOMIZED_MAC_ENABLED,
+    TRACK_RANDOMIZED_MAC_IGNORE,
 )
 from .utils import adjust_mac
 
@@ -60,6 +65,26 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_CONSIDER_HOME, default=DEFAULT_CONSIDER_HOME.total_seconds()
         ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=900)),
+    }
+)
+
+# Options exposed via the options flow: connection details plus settings that
+# only make sense once the integration is running.
+OPTIONS_DATA_SCHEMA = STEP_USER_DATA_SCHEMA.extend(
+    {
+        vol.Optional(
+            CONF_TRACK_RANDOMIZED_MAC, default=DEFAULT_TRACK_RANDOMIZED_MAC
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[
+                    TRACK_RANDOMIZED_MAC_ENABLED,
+                    TRACK_RANDOMIZED_MAC_DISABLED,
+                    TRACK_RANDOMIZED_MAC_IGNORE,
+                ],
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key=CONF_TRACK_RANDOMIZED_MAC,
+            )
+        ),
     }
 )
 
@@ -273,13 +298,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
-                    title="", data=self.config_entry.options | info["data"]
+                    title="",
+                    data=self.config_entry.options
+                    | info["data"]
+                    | {
+                        CONF_TRACK_RANDOMIZED_MAC: user_input[CONF_TRACK_RANDOMIZED_MAC]
+                    },
                 )
-        # This exposes the API key back to the user
+        # Pre-fill from current options (falling back to the connection data)
+        suggested = {**self.config_entry.data, **self.config_entry.options}
         data_schema = self.add_suggested_values_to_schema(
-            STEP_USER_DATA_SCHEMA, self.config_entry.data
+            OPTIONS_DATA_SCHEMA, suggested
         )
-        return self.async_show_form(step_id="init", data_schema=data_schema)
+        return self.async_show_form(
+            step_id="init", data_schema=data_schema, errors=errors
+        )
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/glinet/const.py
+++ b/custom_components/glinet/const.py
@@ -9,3 +9,10 @@ GLINET_DEFAULT_PW = "goodlife"
 GLINET_DEFAULT_USERNAME = "root"
 
 CONF_TITLE = "title"
+
+# How to handle device trackers for clients using MAC-address randomization.
+CONF_TRACK_RANDOMIZED_MAC = "track_randomized_mac"
+TRACK_RANDOMIZED_MAC_ENABLED = "enabled"  # track, entity enabled by default
+TRACK_RANDOMIZED_MAC_DISABLED = "disabled"  # track, entity disabled by default
+TRACK_RANDOMIZED_MAC_IGNORE = "ignore"  # do not create a tracker at all
+DEFAULT_TRACK_RANDOMIZED_MAC = TRACK_RANDOMIZED_MAC_DISABLED

--- a/custom_components/glinet/device_tracker.py
+++ b/custom_components/glinet/device_tracker.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from propcache.api import cached_property
-
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -22,7 +20,7 @@ DEFAULT_DEVICE_NAME = "Unknown device"
 
 
 async def async_setup_entry(
-    _: HomeAssistant,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
@@ -34,6 +32,13 @@ async def async_setup_entry(
     def update_router() -> None:
         """Update the values of the router."""
         add_entities(router, async_add_entities, tracked)
+
+    # Create entities for any devices discovered on subsequent polls, not just
+    # those present at setup. Without this, new devices were only added on a
+    # reload of the integration (issue #139).
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, router.signal_device_new, update_router)
+    )
 
     update_router()
 
@@ -63,9 +68,6 @@ def add_entities(
 class GLinetDevice(ScannerEntity):
     """Representation of a GLinet tracked device."""
 
-    _attr_hostname: str
-    _attr_ip_address: str | None
-    _attr_mac_address: str
     _attr_source_type: SourceType = SourceType.ROUTER
 
     def __init__(self, router: GLinetRouter, device: ClientDevInfo) -> None:
@@ -73,14 +75,11 @@ class GLinetDevice(ScannerEntity):
         self._router: GLinetRouter = router
         self._device: ClientDevInfo = device
         self._icon = "mdi:radar"
-        self._attr_hostname: str = self._device.name or DEFAULT_DEVICE_NAME
-        self._attr_ip_address: str | None = self._device.ip_address
-        self._attr_mac_address: str = self._device.mac
 
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return self._attr_mac_address
+        return self._device.mac
 
     @property
     def icon(self) -> str:
@@ -90,7 +89,7 @@ class GLinetDevice(ScannerEntity):
     @property
     def name(self) -> str:
         """Return the name."""
-        return self._attr_hostname
+        return self._device.name or DEFAULT_DEVICE_NAME
 
     @property
     def is_connected(self) -> bool:
@@ -115,25 +114,25 @@ class GLinetDevice(ScannerEntity):
             )
         return attrs
 
-    @cached_property
+    @property
     def hostname(self) -> str:
         """Return the hostname of device."""
-        return self._attr_hostname
+        return self._device.name or DEFAULT_DEVICE_NAME
 
-    @cached_property
+    @property
     def ip_address(self) -> str | None:
         """Return the primary ip address of the device."""
-        return self._attr_ip_address
+        return self._device.ip_address
 
-    @cached_property
+    @property
     def mac_address(self) -> str | None:
         """Return the mac address of the device."""
-        return self._attr_mac_address
+        return self._device.mac
 
     @property
     def should_poll(self) -> bool:
-        """No polling needed."""
-        return True
+        """State is pushed via the router's dispatcher signal, not polled."""
+        return False
 
     @callback
     def async_on_demand_update(self) -> None:

--- a/custom_components/glinet/device_tracker.py
+++ b/custom_components/glinet/device_tracker.py
@@ -10,6 +10,9 @@ from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+from .const import TRACK_RANDOMIZED_MAC_ENABLED
+from .utils import is_randomized_mac
+
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -102,12 +105,28 @@ class GLinetDevice(ScannerEntity):
         return SourceType.ROUTER
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Decide whether a new tracker is enabled by default.
+
+        Randomized-MAC clients honour the ``track_randomized_mac`` option: only
+        ``enabled`` turns them on by default (``ignore`` stops the entity being
+        created at all - handled in the router). For every other client we
+        defer to Home Assistant's ScannerEntity heuristic, which enables a
+        tracker only when its MAC maps to a known device and otherwise leaves
+        it disabled to avoid surfacing unknown floating MACs.
+        """
+        if is_randomized_mac(self._device.mac):
+            return self._router.randomized_mac_mode == TRACK_RANDOMIZED_MAC_ENABLED
+        return super().entity_registry_enabled_default
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes."""
 
         attrs = {}
 
         attrs["interface_type"] = str(self._device.interface_type)
+        attrs["mac_randomized"] = is_randomized_mac(self._device.mac)
         if self._device.last_activity:
             attrs["last_time_reachable"] = self._device.last_activity.isoformat(
                 timespec="seconds"

--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -337,6 +337,11 @@ class GLinetRouter:
             if wrt_devices is None or wrt_devices == {}:
                 self._connected_devices = 0
             return
+        _LOGGER.debug(
+            "connected_clients returned %d online device(s): %s",
+            len(wrt_devices),
+            list(wrt_devices.keys()),
+        )
         consider_home = self._options.get(
             CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME.total_seconds()
         )
@@ -360,6 +365,12 @@ class GLinetRouter:
             device = ClientDevInfo(device_mac)
             device.update(dev_info)
             self._devices[device_mac] = device
+            _LOGGER.debug(
+                "Discovered new tracked device %s (name=%r alias=%r)",
+                device_mac,
+                dev_info.get("name"),
+                dev_info.get("alias"),
+            )
 
         async_dispatcher_send(self.hass, self.signal_device_update)
         if new_device:

--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -178,7 +178,11 @@ class GLinetRouter:
         # TODO here we ask this to update all on the same scan interval
         # but in future some sensors e.g WANip need to update less regularly than
         # others
-        async_track_time_interval(self.hass, self.update_states, SCAN_INTERVAL)
+        # Register the unsub so the poller is cancelled on unload/reload;
+        # otherwise every reload leaks another timer that keeps polling.
+        self._entry.async_on_unload(
+            async_track_time_interval(self.hass, self.update_states, SCAN_INTERVAL)
+        )
 
     async def get_api(self) -> GLinet:
         """Optimistically returns a GLinet object for connection to the API, no test included."""

--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -352,12 +352,10 @@ class GLinetRouter:
             if device_mac in self._devices:
                 continue
 
-            alias = dev_info.get("alias", "").strip()
-            name = dev_info.get("name", "").strip()
-            # Skip if both alias and name are empty
-            if not alias and not name:
-                continue
-
+            # Track every connected client. Devices without a name or alias
+            # (many IoT devices, e.g. bulbs and sensors) were previously
+            # dropped here, leaving most of the network untracked (issue #139).
+            # ClientDevInfo.update() falls back to a MAC-derived name for these.
             new_device = True
             device = ClientDevInfo(device_mac)
             device.update(dev_info)

--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -401,7 +401,10 @@ class GLinetRouter:
         ifaces = await self._update_platform(self._api.wifi_ifaces_get)
         if not ifaces:
             return
+        new_iface = False
         for name, iface in ifaces.items():
+            if name not in self._wifi_ifaces:
+                new_iface = True
             self._wifi_ifaces[name] = WifiInterface(
                 name=name,
                 enabled=iface.get("enabled", False),
@@ -410,6 +413,8 @@ class GLinetRouter:
                 hidden=iface.get("hidden", False),
                 encryption=iface.get("encryption", "UNKNOWN"),
             )
+        if new_iface:
+            async_dispatcher_send(self.hass, self.signal_iface_new)
 
     async def update_tailscale_state(self) -> None:
         """Make a call to the API to get the tailscale state."""
@@ -516,6 +521,11 @@ class GLinetRouter:
     def signal_device_update(self) -> str:
         """Event specific per GL-iNet entry to signal updates in devices."""
         return f"{DOMAIN}-device-update-{self._factory_mac}"
+
+    @property
+    def signal_iface_new(self) -> str:
+        """Event specific per GL-iNet entry to signal a new WiFi interface."""
+        return f"{DOMAIN}-iface-new-{self._factory_mac}"
 
     @property
     def host(self) -> str:

--- a/custom_components/glinet/router.py
+++ b/custom_components/glinet/router.py
@@ -34,8 +34,14 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
-from .const import API_PATH, DOMAIN
-from .utils import adjust_mac
+from .const import (
+    API_PATH,
+    CONF_TRACK_RANDOMIZED_MAC,
+    DEFAULT_TRACK_RANDOMIZED_MAC,
+    DOMAIN,
+    TRACK_RANDOMIZED_MAC_IGNORE,
+)
+from .utils import adjust_mac, is_randomized_mac
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -361,6 +367,14 @@ class GLinetRouter:
             if device_mac in self._devices:
                 continue
 
+            # Optionally ignore clients using MAC randomization entirely, so
+            # they don't accumulate as (even disabled) entities over time.
+            if (
+                self.randomized_mac_mode == TRACK_RANDOMIZED_MAC_IGNORE
+                and is_randomized_mac(device_mac)
+            ):
+                continue
+
             # Track every connected client. Devices without a name or alias
             # (many IoT devices, e.g. bulbs and sensors) were previously
             # dropped here, leaving most of the network untracked (issue #139).
@@ -517,6 +531,13 @@ class GLinetRouter:
     def devices(self) -> dict[str, ClientDevInfo]:
         """Return devices."""
         return self._devices
+
+    @property
+    def randomized_mac_mode(self) -> str:
+        """How clients using MAC randomization should be tracked."""
+        return self._options.get(
+            CONF_TRACK_RANDOMIZED_MAC, DEFAULT_TRACK_RANDOMIZED_MAC
+        )
 
     @property
     def api(self) -> GLinet:

--- a/custom_components/glinet/strings.json
+++ b/custom_components/glinet/strings.json
@@ -34,14 +34,25 @@
           "username": "[%key:common::config_flow::data::username%]",
           "host": "[%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "consider_home": "Consider Home"
+          "consider_home": "Consider Home",
+          "track_randomized_mac": "Randomized-MAC devices"
         },
         "data_description": {
           "username": "This is always 'root' by default on GL-iNet devices",
           "host": "The hostname or IP address of your GL-iNet router.",
           "password": "The password you use to login to your router's admin page, this is unlikely to be the same as your WiFi password",
-          "consider_home": "Seconds to wait before deciding that a device is away"
+          "consider_home": "Seconds to wait before deciding that a device is away",
+          "track_randomized_mac": "How to handle clients that use MAC-address randomization (e.g. phones). These change address on each reconnection."
         }
+      }
+    }
+  },
+  "selector": {
+    "track_randomized_mac": {
+      "options": {
+        "enabled": "Track (enabled by default)",
+        "disabled": "Track (disabled by default)",
+        "ignore": "Ignore (don't create entities)"
       }
     }
   }

--- a/custom_components/glinet/switch.py
+++ b/custom_components/glinet/switch.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -20,11 +21,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Pi-hole switch."""
+    """Set up the GL-iNet switches."""
     router: GLinetRouter = entry.runtime_data
-    switches: list[WifiApSwitch | WireGuardSwitch | TailscaleSwitch] = []
+    switches: list[WireGuardSwitch | TailscaleSwitch] = []
     if router.wireguard_clients:
         # TODO detect all configured wireguard, openvpn, shadowsocks and
         # TOR clients & servers with router/vpn/status? and gen a switch for each
@@ -34,10 +35,29 @@ async def async_setup_entry(
         ]
     if router.tailscale_configured:
         switches.append(TailscaleSwitch(router))
-    for iface_name, iface in router.wifi_ifaces.items():
-        switches.append(WifiApSwitch(router, iface_name, iface))
     if switches:
         async_add_entities(switches, True)
+
+    tracked_ifaces: set[str] = set()
+
+    @callback
+    def add_wifi_switches() -> None:
+        """Add switches for any WiFi interfaces not yet tracked."""
+        new_switches = []
+        for iface_name, iface in router.wifi_ifaces.items():
+            if iface_name in tracked_ifaces:
+                continue
+            new_switches.append(WifiApSwitch(router, iface_name, iface))
+            tracked_ifaces.add(iface_name)
+        if new_switches:
+            async_add_entities(new_switches, True)
+
+    # Create switches for WiFi interfaces enabled after setup (e.g. MLO), not
+    # just those present at setup, which previously required a reload (#103).
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, router.signal_iface_new, add_wifi_switches)
+    )
+    add_wifi_switches()
 
 
 class GliSwitchBase(SwitchEntity):
@@ -83,7 +103,7 @@ class WifiApSwitch(GliSwitchBase):
     @property
     def name(self) -> str:
         """Return the name of the switch."""
-        return self._iface.ssid if self._iface.ssid else self._iface.name
+        return self._iface.ssid or self._iface.name
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/glinet/translations/en.json
+++ b/custom_components/glinet/translations/en.json
@@ -34,14 +34,25 @@
           "username": "Username",
           "host": "Host",
           "password": "Password",
-          "consider_home": "Consider Home"
+          "consider_home": "Consider Home",
+          "track_randomized_mac": "Randomized-MAC devices"
         },
         "data_description": {
           "username": "This is always 'root' by default on GL-iNet devices",
           "host": "The hostname or IP address of your GL-iNet router.",
           "password": "The password you use to login to your router's admin page, this is unlikely to be the same as your WiFi password",
-          "consider_home": "Seconds to wait before deciding that a device is away"
+          "consider_home": "Seconds to wait before deciding that a device is away",
+          "track_randomized_mac": "How to handle clients that use MAC-address randomization (e.g. phones). These change address on each reconnection."
         }
+      }
+    }
+  },
+  "selector": {
+    "track_randomized_mac": {
+      "options": {
+        "enabled": "Track (enabled by default)",
+        "disabled": "Track (disabled by default)",
+        "ignore": "Ignore (don't create entities)"
       }
     }
   }

--- a/custom_components/glinet/utils.py
+++ b/custom_components/glinet/utils.py
@@ -1,6 +1,22 @@
 """Utility functions for GL-iNet routers."""
 
 
+def is_randomized_mac(mac: str | None) -> bool:
+    """Return True if a MAC address is locally administered (randomized).
+
+    Modern phones use MAC randomization, setting the locally-administered bit
+    (0x02 of the first octet). Such addresses change on each (re)connection, so
+    a tracker keyed on them is short-lived clutter. Detection is purely from the
+    address itself - no router support required. Malformed input is treated as
+    not randomized.
+    """
+    try:
+        first_octet = int(str(mac).replace(":", "").replace("-", "")[:2], 16)
+    except (ValueError, IndexError):
+        return False
+    return bool(first_octet & 0x02)
+
+
 def adjust_mac(mac: str, delta: int, sep: str = ":") -> str:
     """Increment a MAC address by 1.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ known-first-party = [
     "homeassistant",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "INP001", # tests are intentionally not an importable package
+]
+
 [tool.ruff.lint]
 select = [
     "A001", # Variable {name} is shadowing a Python builtin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest setup: make the integration's HA-free helpers importable.
+
+``custom_components/glinet/utils.py`` has no Home Assistant dependencies, so we
+add the package directory to ``sys.path`` to unit test it in isolation.
+"""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parent.parent / "custom_components" / "glinet"),
+)

--- a/tests/test_randomized_mac.py
+++ b/tests/test_randomized_mac.py
@@ -1,0 +1,44 @@
+"""Unit tests for randomized-MAC detection (issue #139 follow-up).
+
+Exercises the pure helper in ``custom_components/glinet/utils.py``; no Home
+Assistant runtime required (path set up in conftest.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+from utils import is_randomized_mac
+
+
+@pytest.mark.parametrize(
+    "mac",
+    [
+        "9A:99:5B:9C:81:37",  # observed randomized phone
+        "96:B9:1F:99:EA:79",  # observed randomized phone
+        "02:00:00:00:00:00",
+        "9a-99-5b-9c-81-37",  # hyphen separator, lower case
+    ],
+)
+def test_randomized_macs(mac: str) -> None:
+    """Locally-administered MACs are detected as randomized."""
+    assert is_randomized_mac(mac) is True
+
+
+@pytest.mark.parametrize(
+    "mac",
+    [
+        "84:9E:56:B2:B2:57",  # real desktop NIC
+        "1C:69:20:93:76:2B",  # real (SLZB-06)
+        "00:06:78:B7:58:52",  # real (Home-Theater)
+        "54:60:09:C0:70:B8",  # real (Chromecast)
+    ],
+)
+def test_real_macs(mac: str) -> None:
+    """Universally-administered (real hardware) MACs are not randomized."""
+    assert is_randomized_mac(mac) is False
+
+
+@pytest.mark.parametrize("mac", ["", "xx", "g", None])
+def test_malformed_mac_is_safe(mac: str | None) -> None:
+    """Malformed/missing input never raises and defaults to not-randomized."""
+    assert is_randomized_mac(mac) is False


### PR DESCRIPTION
Closes #103.

WiFi access-point switches were only created in `switch.async_setup_entry`, so an interface enabled after setup (e.g. MLO, or a guest/IoT SSID toggled on later) never got a switch until the integration was reloaded.

## Change

Adds a `signal_iface_new` dispatcher that `update_wifi_ifaces_state()` fires when it first sees a new interface name, and subscribes the switch platform to it (mirroring the device-tracker discovery pattern). New WiFi interfaces now get switches on the regular poll. Also replaces a ternary with `or` in `WifiApSwitch.name` to keep the file ruff-clean.

## Stacked on #146

This is stacked on #146 (#139 device-tracking). **Until #146 merges, this PR's diff also shows #146's commits — please review/merge #146 first**, after which only the switch commit remains here.

## Testing

Validated live on a GL-iNet MT6000: renaming/enabling a WiFi interface relabels its existing switch (keyed on the stable interface name) without churn. The new-interface dispatcher mirrors the device-tracker discovery path that was confirmed live with a phone join; the MT6000 (Wi-Fi 6) has no spare interface slot to create a brand-new `iface` name, so the MLO trigger is validated by analogy to that identical pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)