### PR TITLE
Fix sensor setup mutating its list while iterating

### DIFF
--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -170,11 +170,12 @@ async def async_setup_entry(
         )
     )
 
-    for sensor in sensors:
-        if sensor.native_value is None:
-            sensors.remove(sensor)
+    # Only add sensors whose value is available on this device/model. Build a
+    # new list rather than mutating `sensors` while iterating it, which would
+    # skip elements and leave unavailable sensors in place.
+    available = [sensor for sensor in sensors if sensor.native_value is not None]
 
-    async_add_entities(sensors, True)
+    async_add_entities(available, True)
 
 
 def _uptime_calculation(seconds_uptime: float, last_value: datetime | None) -> datetime:

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -170,9 +170,6 @@ async def async_setup_entry(
         )
     )
 
-    # Only add sensors whose value is available on this device/model. Build a
-    # new list rather than mutating `sensors` while iterating it, which would
-    # skip elements and leave unavailable sensors in place.
     available = [sensor for sensor in sensors if sensor.native_value is not None]
 
     async_add_entities(available, True)


### PR DESCRIPTION
## Summary

`async_setup_entry` in `sensor.py` filters out sensors whose value isn't available on the current device/model by removing them from the list **while iterating that same list**. That skips elements, so some unavailable sensors can be added anyway.

## The bug

```python
for sensor in sensors:
    if sensor.native_value is None:
        sensors.remove(sensor)

async_add_entities(sensors, True)
```

Removing an item during iteration shifts every later element down by one, and the loop's internal index still advances — so the entry immediately **after** a removed one is never examined. Example: if two unavailable sensors are adjacent, only the first is dropped; the second slips through and gets added with a `None` value.

## Fix

Build a new filtered list instead of mutating during iteration:

```python
# Only add sensors whose value is available on this device/model. Build a
# new list rather than mutating `sensors` while iterating it, which would
# skip elements and leave unavailable sensors in place.
available = [sensor for sensor in sensors if sensor.native_value is not None]

async_add_entities(available, True)
```

## Notes

- Pre-existing bug on `master`, independent of the uptime sensor work — split into its own PR for a clean, isolated change.
- `ruff check` and `py_compile` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
