### PR TITLE
Convert the integration to DataUpdateCoordinator

### DIFF
--- a/custom_components/glinet/__init__.py
+++ b/custom_components/glinet/__init__.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING
 from .coordinator import GLinetUpdateCoordinator
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+    from .coordinator import GlinetConfigEntry
 
 PLATFORMS = ["button", "device_tracker", "sensor", "switch"]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: GlinetConfigEntry) -> bool:
     """Set up GL-iNet from a config entry.
 
     Called by home assistant on initial config, restart and
@@ -29,19 +30,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: GlinetConfigEntry) -> bool:
     """Unload a config entry.
 
     The coordinator's polling timer is owned by Home Assistant and torn down
     automatically with the config entry, so only the platforms need unloading.
     """
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update when config_entry options update."""
-    coordinator: GLinetUpdateCoordinator = entry.runtime_data
-
-    # Currently update_options() never returns True
-    if coordinator.update_options(dict(entry.options)):
-        await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/glinet/__init__.py
+++ b/custom_components/glinet/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .router import GLinetRouter
+from .coordinator import GLinetUpdateCoordinator
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -19,27 +19,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     Called by home assistant on initial config, restart and
     component reload.
     """
+    coordinator = GLinetUpdateCoordinator(hass, entry)
+    await coordinator.async_setup()
+    await coordinator.async_config_entry_first_refresh()
 
-    # Store an API object for platforms to access
-    router = GLinetRouter(hass, entry)
-    await router.setup()
-
-    entry.runtime_data = router
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+    """Unload a config entry.
 
+    The coordinator's polling timer is owned by Home Assistant and torn down
+    automatically with the config entry, so only the platforms need unloading.
+    """
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update when config_entry options update."""
-    router: GLinetRouter = entry.runtime_data
+    coordinator: GLinetUpdateCoordinator = entry.runtime_data
 
-    # Currently router.update_options() never returns True
-    if router.update_options(dict(entry.options)):
+    # Currently update_options() never returns True
+    if coordinator.update_options(dict(entry.options)):
         await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/glinet/button.py
+++ b/custom_components/glinet/button.py
@@ -1,4 +1,4 @@
-"""Support for turning on and off Pi-hole system."""
+"""Button platform for the GL-iNet integration."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .router import GLinetRouter
+    from .coordinator import GLinetUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,39 +22,30 @@ async def async_setup_entry(
     _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the button entities."""
-    router: GLinetRouter = entry.runtime_data
-    buttons: list[RebootButton] = []
-    buttons.append(RebootButton(router))
-    if buttons:
-        async_add_entities(buttons, True)
+    coordinator: GLinetUpdateCoordinator = entry.runtime_data
+    async_add_entities([RebootButton(coordinator)])
 
 
 class RebootButton(ButtonEntity):
     """Reboot button."""
 
-    def __init__(self, router: GLinetRouter) -> None:
-        """Initialize a GLinet device."""
-        self._router = router
-        self._attr_device_info = router.device_info
-
     _attr_icon = "mdi:restart"
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: GLinetUpdateCoordinator) -> None:
+        """Initialize a GLinet device."""
+        self._coordinator = coordinator
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = (
+            f"glinet_button/{coordinator.factory_mac}/reboot"
+        )
 
     @property
     def name(self) -> str:
         """Return the name of the button."""
         return "Reboot"
 
-    @property
-    def unique_id(self) -> str:
-        """Return the unique id of the button."""
-        return f"glinet_button/{self._router.factory_mac}/reboot"
-
     async def async_press(self) -> None:
         """Reboot the router."""
-        await self._router.api.router_reboot()
-
-    @property
-    def entity_category(self) -> EntityCategory:
-        """A config entity."""
-        return EntityCategory.CONFIG
+        await self._coordinator.api.router_reboot()

--- a/custom_components/glinet/button.py
+++ b/custom_components/glinet/button.py
@@ -7,26 +7,25 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import GLinetUpdateCoordinator
+    from .coordinator import GlinetConfigEntry, GLinetUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    _: HomeAssistant, entry: GlinetConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the button entities."""
-    coordinator: GLinetUpdateCoordinator = entry.runtime_data
-    async_add_entities([RebootButton(coordinator)])
+    async_add_entities([RebootButton(entry.runtime_data)])
 
 
-class RebootButton(ButtonEntity):
+class RebootButton(CoordinatorEntity["GLinetUpdateCoordinator"], ButtonEntity):
     """Reboot button."""
 
     _attr_icon = "mdi:restart"
@@ -35,11 +34,9 @@ class RebootButton(ButtonEntity):
 
     def __init__(self, coordinator: GLinetUpdateCoordinator) -> None:
         """Initialize a GLinet device."""
-        self._coordinator = coordinator
+        super().__init__(coordinator)
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = (
-            f"glinet_button/{coordinator.factory_mac}/reboot"
-        )
+        self._attr_unique_id = f"glinet_button/{coordinator.factory_mac}/reboot"
 
     @property
     def name(self) -> str:
@@ -48,4 +45,4 @@ class RebootButton(ButtonEntity):
 
     async def async_press(self) -> None:
         """Reboot the router."""
-        await self._coordinator.api.router_reboot()
+        await self.coordinator.api.router_reboot()

--- a/custom_components/glinet/config_flow.py
+++ b/custom_components/glinet/config_flow.py
@@ -63,6 +63,17 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME, default=GLINET_DEFAULT_USERNAME): (
+            selector.TextSelector()
+        ),
+        vol.Required(CONF_PASSWORD): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
+    }
+)
+
 
 class TestingHub:
     """Testing class to test connection and authentication."""
@@ -196,6 +207,47 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 STEP_USER_DATA_SCHEMA, defaults
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, _: dict[str, Any]) -> ConfigFlowResult:
+        """Handle re-authentication when the stored token is rejected.
+
+        Triggered by the coordinator raising ``ConfigEntryAuthFailed``; prompts
+        for fresh credentials and refreshes the stored token in place.
+        """
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm re-authentication with a freshly entered password."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            data = {**reauth_entry.data, **user_input}
+            try:
+                info = await validate_input(data, self.hass)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            # Broad excepts are permitted in config flows
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates=info["data"]
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_REAUTH_DATA_SCHEMA,
+                {CONF_USERNAME: reauth_entry.data.get(CONF_USERNAME)},
             ),
             errors=errors,
         )

--- a/custom_components/glinet/const.py
+++ b/custom_components/glinet/const.py
@@ -1,6 +1,9 @@
 """Constants for the GL-iNet integration."""
 
+from datetime import timedelta
+
 DOMAIN = "glinet"
+SCAN_INTERVAL = timedelta(seconds=30)
 DATA_GLINET = "glinet"
 API_PATH = "/rpc"
 GLINET_FRIENDLY_NAME = "GL-iNet"

--- a/custom_components/glinet/coordinator.py
+++ b/custom_components/glinet/coordinator.py
@@ -57,7 +57,7 @@ class GLinetData:
     devices: dict[str, ClientDevInfo] = field(default_factory=dict)
     connected_devices: int = 0
     wifi_ifaces: dict[str, WifiInterface] = field(default_factory=dict)
-    wireguard_clients: dict[str, WireGuardClient] = field(default_factory=dict)
+    wireguard_clients: dict[int, WireGuardClient] = field(default_factory=dict)
     wireguard_connections: list[WireGuardClient] = field(default_factory=list)
     tailscale_config: dict = field(default_factory=dict)
     tailscale_connection: bool | None = None
@@ -97,7 +97,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         self._connected_devices: int = 0
         self._wifi_ifaces: dict[str, WifiInterface] = {}
         self._system_status: dict = {}
-        self._wireguard_clients: dict[str, WireGuardClient] = {}
+        self._wireguard_clients: dict[int, WireGuardClient] = {}
         self._wireguard_connections: list[WireGuardClient] = []
         self._tailscale_config: dict = {}
         self._tailscale_connection: bool | None = None

--- a/custom_components/glinet/coordinator.py
+++ b/custom_components/glinet/coordinator.py
@@ -47,7 +47,11 @@ T = TypeVar("T")
 
 @dataclass
 class GLinetData:
-    """Immutable-ish snapshot of router state exposed to entities each refresh."""
+    """Snapshot of router state exposed to entities each refresh.
+
+    Holds references to the coordinator's working collections (not copies);
+    entities read it fresh after every coordinator update.
+    """
 
     system_status: dict = field(default_factory=dict)
     devices: dict[str, ClientDevInfo] = field(default_factory=dict)
@@ -350,7 +354,15 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
 
     async def update_tailscale_state(self) -> None:
         """Make a call to the API to get the tailscale state."""
-        if not await self._api.tailscale_configured():
+        # tailscale_configured() is a plain API call (no _update_platform
+        # wrapper), so guard it: a transient error must not abort the whole
+        # refresh or escape uncaught.
+        try:
+            configured = await self._api.tailscale_configured()
+        except (TimeoutError, NonZeroResponse, TokenError, OSError) as err:
+            _LOGGER.debug("Could not determine tailscale state: %s", err)
+            return
+        if not configured:
             self._tailscale_config = {}
             return
         self._tailscale_config = (

--- a/custom_components/glinet/coordinator.py
+++ b/custom_components/glinet/coordinator.py
@@ -1,10 +1,8 @@
-"""Represent the GLinet router."""
+"""DataUpdateCoordinator for the GL-iNet integration."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -29,12 +27,11 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.util import dt as dt_util
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import API_PATH, DOMAIN
+from .const import API_PATH, DOMAIN, SCAN_INTERVAL
+from .models import ClientDevInfo, WifiInterface, WireGuardClient
 from .utils import adjust_mac
 
 if TYPE_CHECKING:
@@ -45,66 +42,60 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_registry import RegistryEntry
 
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(seconds=30)
 T = TypeVar("T")
 
 
-class DeviceInterfaceType(StrEnum):
-    """Enum for the possible interface types reported by glipy."""
+@dataclass
+class GLinetData:
+    """Immutable-ish snapshot of router state exposed to entities each refresh."""
 
-    WIFI_24 = "2.4GHz"
-    WIFI_5 = "5GHz"
-    LAN = "LAN"
-    WIFI_24_GUEST = "2.4GHz Guest"
-    WIFI_5_GUEST = "5GHz Guest"
-    UNKNOWN = "Unknown"
-    DONGLE = "Dongle"
-    BYPASS_ROUTE = "Bypass Route"
-    UNKNOWN2 = "Unknown"
-    MLO = "MLO"
-    MLO_GUEST = "MLO Guest"
-    WIFI_6 = "6GHz"
-    WIFI_6_GUEST = "6GHz Guest"
+    system_status: dict = field(default_factory=dict)
+    devices: dict[str, ClientDevInfo] = field(default_factory=dict)
+    connected_devices: int = 0
+    wifi_ifaces: dict[str, WifiInterface] = field(default_factory=dict)
+    wireguard_clients: dict[str, WireGuardClient] = field(default_factory=dict)
+    wireguard_connections: list[WireGuardClient] = field(default_factory=list)
+    tailscale_config: dict = field(default_factory=dict)
+    tailscale_connection: bool | None = None
 
 
-class GLinetRouter:
-    """representation of a GLinet router.
+class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
+    """Coordinate polling of a GL-iNet router and own its API client.
 
-    Should comprise: A method to access the gli4py API
-    Basic data and properties about the router
-    Configure a home assistant device
-    ?TODO make calls to the sensors and device trackers
-    that are connected to it.
+    Replaces the old ``GLinetRouter``: it holds the device identity and the
+    gli4py client, and produces a ``GLinetData`` snapshot every ``SCAN_INTERVAL``
+    which all entities consume via ``CoordinatorEntity``.
     """
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize a GLinet router.
+    config_entry: ConfigEntry
 
-        Should not be called directly,
-        unless then calling async_init().
-        """
-        # Context info
-        self.hass: HomeAssistant = hass
-        self._entry: ConfigEntry = entry
-        self._options: dict = {}
-        self._options.update(entry.options)
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            config_entry=entry,
+        )
+        self._options: dict = dict(entry.options)
 
         # gli4py API
         self._api: GLinet
         self._host: str = entry.data[CONF_HOST]
 
-        # Stable properties
+        # Stable identity
         self._factory_mac: str = "UNKNOWN"
         self._model: str = "UNKNOWN"
         self._sw_v: str = "UNKNOWN"
 
-        # State
+        # Persistent accumulators referenced by the GLinetData snapshot
         self._devices: dict[str, ClientDevInfo] = {}
         self._connected_devices: int = 0
         self._wifi_ifaces: dict[str, WifiInterface] = {}
         self._system_status: dict = {}
         self._wireguard_clients: dict[str, WireGuardClient] = {}
-        self._wireguard_connections: list[WireGuardClient] | None = None
+        self._wireguard_connections: list[WireGuardClient] = []
         self._tailscale_config: dict = {}
         self._tailscale_connection: bool | None = None
 
@@ -113,56 +104,24 @@ class GLinetRouter:
         self._connect_error: bool = False
         self._token_error: bool = False
 
-    async def async_init(self) -> None:
-        """Set up a GL-iNet router.
+    # ------------------------------------------------------------------
+    # Setup / authentication
+    # ------------------------------------------------------------------
 
-        Do some late initialization
+    async def async_setup(self) -> None:
+        """Authenticate, load identity and restore known trackers.
+
+        Called once from ``async_setup_entry`` before the first refresh.
         """
-
-        try:
-            self._api = await self.get_api()
-            await self._api.login(
-                self._entry.data[CONF_USERNAME], self._entry.data[CONF_PASSWORD]
-            )
-        except OSError as exc:
-            _LOGGER.exception(
-                "Error connecting to GL-iNet router %s",
-                self._host,
-            )
-            raise ConfigEntryNotReady from exc
-        try:
-            router_info = await self._update_platform(self._api.router_info)
-            assert router_info is not None
-        except Exception as exc:  # pylint: disable=broad-except
-            # The late initialized variables will remain in
-            # their default 'UNKNOWN' state
-            _LOGGER.exception(
-                "Error getting basic device info from GL-iNet router %s",
-                self._host,
-            )
-            raise ConfigEntryNotReady from exc
-
-        _LOGGER.debug("Router info retrieved: %s", router_info)
-        self._model = router_info[CONF_MODEL]
-        self._sw_v = router_info["firmware_version"]
-        self._factory_mac = router_info[CONF_MAC]
-
-        self._late_init_complete = True
-
-    async def setup(self) -> None:
-        """Load in old and new entities and establish a new session token."""
-
         if not self._late_init_complete:
             await self.async_init()
 
-        # On setup we may already have saved tracker entities
-        # Load them in and save them to the class
+        # Restore device-tracker entities saved from a previous run so we keep
+        # reporting them (and apply consider_home) even before they reappear.
         entity_registry = er.async_get(self.hass)
-
         track_entries: list[RegistryEntry] = er.async_entries_for_config_entry(
-            entity_registry, self._entry.entry_id
+            entity_registry, self.config_entry.entry_id
         )
-
         for entry in track_entries:
             if entry.domain == TRACKER_DOMAIN:
                 self._devices[entry.unique_id] = ClientDevInfo(
@@ -172,17 +131,35 @@ class GLinetRouter:
         # Each new setup should renew the token
         await self.renew_token()
 
-        # Update device tracker and switch entities
-        await self.update_all()
+    async def async_init(self) -> None:
+        """Connect to the router and read its stable identity."""
+        try:
+            self._api = await self.get_api()
+            await self._api.login(
+                self.config_entry.data[CONF_USERNAME],
+                self.config_entry.data[CONF_PASSWORD],
+            )
+        except OSError as exc:
+            _LOGGER.exception("Error connecting to GL-iNet router %s", self._host)
+            raise ConfigEntryNotReady from exc
+        try:
+            router_info = await self._update_platform(self._api.router_info)
+            assert router_info is not None
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Error getting basic device info from GL-iNet router %s", self._host
+            )
+            raise ConfigEntryNotReady from exc
 
-        # TODO here we ask this to update all on the same scan interval
-        # but in future some sensors e.g WANip need to update less regularly than
-        # others
-        async_track_time_interval(self.hass, self.update_states, SCAN_INTERVAL)
+        _LOGGER.debug("Router info retrieved: %s", router_info)
+        self._model = router_info[CONF_MODEL]
+        self._sw_v = router_info["firmware_version"]
+        self._factory_mac = router_info[CONF_MAC]
+        self._late_init_complete = True
 
     async def get_api(self) -> GLinet:
-        """Optimistically returns a GLinet object for connection to the API, no test included."""
-        conf = self._entry.data
+        """Optimistically return a GLinet client, no test included."""
+        conf = self.config_entry.data
         shared_session = async_get_clientsession(self.hass)
         ha_client = AiohttpClient(session=shared_session)
 
@@ -201,12 +178,10 @@ class GLinetRouter:
         """Attempt to get a new token."""
         try:
             await self._api.login(
-                self._entry.data[CONF_USERNAME], self._entry.data[CONF_PASSWORD]
+                self.config_entry.data[CONF_USERNAME],
+                self.config_entry.data[CONF_PASSWORD],
             )
-            _LOGGER.info(
-                "GL-iNet router %s token was renewed",
-                self._host,
-            )
+            _LOGGER.info("GL-iNet router %s token was renewed", self._host)
         except (AuthenticationError, TokenError) as exc:
             _LOGGER.exception(
                 "GL-iNet %s failed to renew the token, have you changed your router password?",
@@ -219,27 +194,40 @@ class GLinetRouter:
             )
             raise  # Let generic network/timeout exceptions bubble up normally
 
-    async def update_all(self, _: datetime | None = None) -> None:
-        """Update all Gl-inet platforms."""
-        await self.update_system_status()
+    # ------------------------------------------------------------------
+    # Polling
+    # ------------------------------------------------------------------
+
+    async def _async_update_data(self) -> GLinetData:
+        """Fetch a fresh snapshot of router state."""
+        status = await self._update_platform(self._api.router_get_status)
+        if status is None:
+            # The core health call failed (router unreachable / token not yet
+            # recovered). Surface it so entities go unavailable; the token error
+            # flag triggers a renewal attempt on the next cycle.
+            raise UpdateFailed(f"Unable to reach GL-iNet router {self._host}")
+        self._system_status = status.get("system", {})
+
         await self.update_device_trackers()
         await self.update_wifi_ifaces_state()
         await self.update_wireguard_client_state()
         await self.update_tailscale_state()
 
-    async def update_states(self, _: datetime | None = None) -> None:
-        """Update platforms and states that aren't handled elsewhere."""
-        await self.update_system_status()
-        await self.update_device_trackers()
-        # If a user may have many switches, best to update in bulk
-        await self.update_wifi_ifaces_state()
-        await self.update_wireguard_client_state()
+        return GLinetData(
+            system_status=self._system_status,
+            devices=self._devices,
+            connected_devices=self._connected_devices,
+            wifi_ifaces=self._wifi_ifaces,
+            wireguard_clients=self._wireguard_clients,
+            wireguard_connections=self._wireguard_connections,
+            tailscale_config=self._tailscale_config,
+            tailscale_connection=self._tailscale_connection,
+        )
 
     async def _update_platform(
         self, api_callable: Callable[[], Coroutine[Any, Any, T]]
     ) -> T | None:
         """Boilerplate to make update requests to api and handle errors."""
-
         try:
             if self._token_error:
                 _LOGGER.debug(
@@ -257,8 +245,7 @@ class GLinetRouter:
             if not self._connect_error:
                 self._connect_error = True
                 _LOGGER.exception(
-                    "GL-iNet router %s did not respond in time",
-                    self._host,
+                    "GL-iNet router %s did not respond in time", self._host
                 )
             return None
         except TokenError as exc:
@@ -279,7 +266,7 @@ class GLinetRouter:
                 )
             return None
         except ConfigEntryAuthFailed:
-            # Bubble up to Home Assistant to pause polling and trigger the re-auth flow
+            # Bubble up to Home Assistant to pause polling and trigger re-auth
             raise
         except Exception:  # pylint: disable=broad-except  # noqa: BLE001
             if not self._connect_error:
@@ -308,25 +295,10 @@ class GLinetRouter:
         if self._connect_error:
             self._connect_error = False
             _LOGGER.info("Reconnected to Gl-inet router %s", self._host)
-        _LOGGER.debug(
-            "_update_platform() completed without error for callable %s, returning response: %s",
-            api_callable.__name__,
-            str(response)[:200],
-        )
         return response
-
-    async def update_system_status(self) -> None:
-        """Update the system status from the API."""
-
-        status = await self._update_platform(self._api.router_get_status)
-        # For now only the content of the `system` field seems of use
-        if status:
-            self._system_status = status.get("system", {})
 
     async def update_device_trackers(self) -> None:
         """Update the device trackers."""
-
-        new_device = False
         wrt_devices = await self._update_platform(self._api.connected_clients)
         if not wrt_devices:
             _LOGGER.warning(
@@ -340,15 +312,12 @@ class GLinetRouter:
         consider_home = self._options.get(
             CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME.total_seconds()
         )
-        # track_unknown = self._options.get(CONF_TRACK_UNKNOWN, DEFAULT_TRACK_UNKNOWN)
 
-        # TODO - ensure the output of gli4py devices has the correct data structure
         for device_mac, device in self._devices.items():
             dev_info = wrt_devices.get(device_mac)
             device.update(dev_info, consider_home)
 
         for device_mac, dev_info in wrt_devices.items():
-            # Skip if we've already have this device
             if device_mac in self._devices:
                 continue
 
@@ -358,14 +327,9 @@ class GLinetRouter:
             if not alias and not name:
                 continue
 
-            new_device = True
             device = ClientDevInfo(device_mac)
             device.update(dev_info)
             self._devices[device_mac] = device
-
-        async_dispatcher_send(self.hass, self.signal_device_update)
-        if new_device:
-            async_dispatcher_send(self.hass, self.signal_device_new)
 
         self._connected_devices = len(wrt_devices)
 
@@ -386,11 +350,9 @@ class GLinetRouter:
 
     async def update_tailscale_state(self) -> None:
         """Make a call to the API to get the tailscale state."""
-
         if not await self._api.tailscale_configured():
             self._tailscale_config = {}
             return
-        # TODO this is a placeholder that needs to be replaced with a pulic method that combines useful info in _tailscale_status and _tailscale_get_config
         self._tailscale_config = (
             await self._update_platform(
                 self._api._tailscale_get_config  # pylint: disable=protected-access  # noqa: SLF001
@@ -400,23 +362,13 @@ class GLinetRouter:
         response: TailscaleConnection = await self._update_platform(
             self._api.tailscale_connection_state
         )
-
-        if response == TailscaleConnection.CONNECTED:
-            self._tailscale_connection = True
-        else:
-            self._tailscale_connection = False
+        self._tailscale_connection = response == TailscaleConnection.CONNECTED
 
     async def update_wireguard_client_state(self) -> None:
         """Make call to the API to get the wireguard client state."""
-        # TODO as part of changes to switch.py, this probably needs to become
-        # client/server/VPN type agnostic it may be that router/vpn/status
-        # is a better API endpoint to do it in only 1 call
         response = await self._update_platform(self._api.wireguard_client_list)
         if not response:
             return
-        # TODO wireguard_client_list outputs some private info, we don't want it to end up in the logs.
-        # TODO we need to do some validation before we start accessing dictionary keys, I've had errors before
-        # May be best to redact it in gli4py.
         for config in response:
             self._wireguard_clients[config["peer_id"]] = WireGuardClient(
                 name=config["name"],
@@ -448,27 +400,23 @@ class GLinetRouter:
                 client.tunnel_id = config.get("tunnel_id", None)
                 client.connected = connected
                 if connected:
-                    # If more modern firmware supports more than 1 client being connected, we need to change this
                     self._wireguard_connections.append(client)
 
     def update_options(self, new_options: dict) -> bool:
-        """Update router options.
-
-        Returns True if a reload is required
-        Called in __init__.py
-        placeholder function because it may become
-        necessary to reload in future.
-        """
+        """Update options. Returns True if a reload is required."""
         req_reload = False
         self._options.update(new_options)
         return req_reload
 
+    # ------------------------------------------------------------------
+    # Identity properties consumed by entities
+    # ------------------------------------------------------------------
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
-
         return DeviceInfo(
-            identifiers={(DOMAIN, self._entry.unique_id or self.factory_mac)},
+            identifiers={(DOMAIN, self.config_entry.unique_id or self.factory_mac)},
             connections={
                 (CONNECTION_NETWORK_MAC, format_mac(self.factory_mac)),
                 (CONNECTION_NETWORK_MAC, adjust_mac(self.factory_mac, 1)),
@@ -481,29 +429,9 @@ class GLinetRouter:
         )
 
     @property
-    def signal_device_new(self) -> str:
-        """Event specific per GL-iNet entry to signal new device."""
-        return f"{DOMAIN}-device-new-{self._factory_mac}"
-
-    @property
-    def signal_device_update(self) -> str:
-        """Event specific per GL-iNet entry to signal updates in devices."""
-        return f"{DOMAIN}-device-update-{self._factory_mac}"
-
-    @property
     def host(self) -> str:
         """Return router host."""
         return self._host
-
-    @property
-    def unique_id(self) -> str:
-        """Return router unique id."""
-        return self._entry.unique_id or self._entry.entry_id
-
-    @property
-    def devices(self) -> dict[str, ClientDevInfo]:
-        """Return devices."""
-        return self._devices
 
     @property
     def api(self) -> GLinet:
@@ -523,144 +451,4 @@ class GLinetRouter:
     @property
     def name(self) -> str:
         """Return router name."""
-        # TODO retrieve the friendly name of the router e.g MT1300 is Beryl
         return f"GL-iNet {self._model.upper()}"
-
-    @property
-    def wifi_ifaces(self) -> dict[str, WifiInterface]:
-        """Return router wifi interfaces."""
-        return self._wifi_ifaces
-
-    @property
-    def wireguard_clients(self) -> dict[str, WireGuardClient]:
-        """Return router factory_mac."""
-        return self._wireguard_clients
-
-    @property
-    def connected_wireguard_clients(self) -> None | list[WireGuardClient]:
-        """Return the wirguard client that is connected, if any."""
-        return self._wireguard_connections
-
-    @property
-    def wireguard_connections(self) -> None | list[WireGuardClient]:
-        """Return the wirguard client that is connected, if any."""
-        # TODO this property looks like a duplicate of the above
-        return self._wireguard_connections
-
-    @property
-    def tailscale_configured(self) -> bool:
-        """Is tailscale configured."""
-        return self._tailscale_config != {}
-
-    @property
-    def tailscale_connection(self) -> bool | None:
-        """Property for tailscale connection."""
-        if not self.tailscale_configured:
-            return None
-        return self._tailscale_connection
-
-    @property
-    def tailscale_config(self) -> dict:
-        """Property for tailscale connection."""
-        # TODO, we need a non private API method that returns some useful config info
-        return self._tailscale_config
-
-    @property
-    def system_status(self) -> dict:
-        """Property for system status."""
-
-        return self._system_status
-
-
-@dataclass
-class WireGuardClient:
-    """Class for keeping track of WireGuard Client Configs."""
-
-    name: str
-    connected: bool = field(compare=False)
-    group_id: int
-    peer_id: int
-    tunnel_id: int | None
-
-
-@dataclass
-class WifiInterface:
-    """Class for keeping track of Wifi Interfaces."""
-
-    name: str
-    enabled: bool
-    ssid: str
-    guest: bool
-    hidden: bool
-    encryption: str
-
-
-class ClientDevInfo:
-    """Representation of a device connected to the router."""
-
-    def __init__(self, mac: str, name: str | None = None) -> None:
-        """Initialize a connected device."""
-        self._mac: str = mac
-        self._name: str | None = name
-        self._ip_address: str | None = None
-        self._last_activity: datetime = dt_util.utcnow() - timedelta(days=1)
-        self._connected: bool = False
-        self._if_type: DeviceInterfaceType = DeviceInterfaceType.UNKNOWN
-
-    def update(self, dev_info: dict | None = None, consider_home: int = 0) -> None:
-        """Update connected device info."""
-        now: datetime = dt_util.utcnow()
-        if dev_info:
-            # Prefer the user-defined alias as a name
-            alias = dev_info.get("alias")
-            if alias and alias.strip():
-                self._name = alias
-            else:
-                # If no alias, fallback to auto-assigned name field
-                name = dev_info.get("name", "")
-                if name == "*" or not name.strip():
-                    self._name = self._mac.replace(":", "_")
-                else:
-                    self._name = name
-            self._ip_address = dev_info.get("ip")
-            self._last_activity = now
-            self._connected = dev_info.get("online", False)
-            self._if_type = list(DeviceInterfaceType)[
-                dev_info.get("type", 5)
-            ]  # TODO be more index safe
-        # a device might not actually be online but we want to consider it home
-        elif self._connected:
-            self._connected = (
-                now - self._last_activity
-            ).total_seconds() < consider_home
-            self._ip_address = None
-
-    @property
-    def is_connected(self) -> bool:
-        """Return connected status."""
-        return self._connected
-
-    @property
-    def interface_type(self) -> DeviceInterfaceType:
-        """Return device interface type."""
-        return self._if_type
-
-    @property
-    def mac(self) -> str:
-        """Return device mac address."""
-        return self._mac
-
-    @property
-    def name(self) -> str | None:
-        """Return device name."""
-        return self._name
-
-    @property
-    def ip_address(self) -> str | None:
-        """Return device ip address."""
-        return self._ip_address
-
-    @property
-    def last_activity(self) -> datetime:
-        """Return device last activity."""
-        return self._last_activity

--- a/custom_components/glinet/coordinator.py
+++ b/custom_components/glinet/coordinator.py
@@ -325,7 +325,9 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
 
         for device_mac, device in self._devices.items():
             dev_info = wrt_devices.get(device_mac)
-            device.update(dev_info, consider_home)
+            device.update(
+                dev_info, consider_home, model=self._model, firmware=self._sw_v
+            )
 
         for device_mac, dev_info in wrt_devices.items():
             if device_mac in self._devices:
@@ -337,7 +339,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
                 continue
 
             device = ClientDevInfo(device_mac)
-            device.update(dev_info)
+            device.update(dev_info, model=self._model, firmware=self._sw_v)
             self._devices[device_mac] = device
 
         self._connected_devices = len(wrt_devices)

--- a/custom_components/glinet/coordinator.py
+++ b/custom_components/glinet/coordinator.py
@@ -16,6 +16,7 @@ from homeassistant.components.device_tracker import (
     DEFAULT_CONSIDER_HOME,
     DOMAIN as TRACKER_DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
@@ -37,7 +38,6 @@ from .utils import adjust_mac
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_registry import RegistryEntry
 
@@ -75,6 +75,8 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
+        # always_update stays True (default): trackers mutate state in place, so
+        # always_update=False would compare snapshots equal and drop their updates.
         super().__init__(
             hass,
             _LOGGER,
@@ -84,16 +86,13 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         )
         self._options: dict = dict(entry.options)
 
-        # gli4py API
         self._api: GLinet
         self._host: str = entry.data[CONF_HOST]
 
-        # Stable identity
         self._factory_mac: str = "UNKNOWN"
         self._model: str = "UNKNOWN"
         self._sw_v: str = "UNKNOWN"
 
-        # Persistent accumulators referenced by the GLinetData snapshot
         self._devices: dict[str, ClientDevInfo] = {}
         self._connected_devices: int = 0
         self._wifi_ifaces: dict[str, WifiInterface] = {}
@@ -103,14 +102,12 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         self._tailscale_config: dict = {}
         self._tailscale_connection: bool | None = None
 
-        # Flow control
         self._late_init_complete: bool = False
         self._connect_error: bool = False
         self._token_error: bool = False
-
-    # ------------------------------------------------------------------
-    # Setup / authentication
-    # ------------------------------------------------------------------
+        # Set by _update_platform when any call hits a transport error this
+        # cycle, so _async_update_data can fail the whole refresh
+        self._cycle_failed: bool = False
 
     async def async_setup(self) -> None:
         """Authenticate, load identity and restore known trackers.
@@ -132,7 +129,6 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
                     entry.unique_id, entry.original_name
                 )
 
-        # Each new setup should renew the token
         await self.renew_token()
 
     async def async_init(self) -> None:
@@ -198,12 +194,9 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
             )
             raise  # Let generic network/timeout exceptions bubble up normally
 
-    # ------------------------------------------------------------------
-    # Polling
-    # ------------------------------------------------------------------
-
     async def _async_update_data(self) -> GLinetData:
         """Fetch a fresh snapshot of router state."""
+        self._cycle_failed = False
         status = await self._update_platform(self._api.router_get_status)
         if status is None:
             # The core health call failed (router unreachable / token not yet
@@ -216,6 +209,12 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         await self.update_wifi_ifaces_state()
         await self.update_wireguard_client_state()
         await self.update_tailscale_state()
+
+        # If any call hit a transport error this cycle, fail the whole refresh
+        if self._cycle_failed:
+            raise UpdateFailed(
+                f"One or more calls to GL-iNet router {self._host} failed"
+            )
 
         return GLinetData(
             system_status=self._system_status,
@@ -232,6 +231,9 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         self, api_callable: Callable[[], Coroutine[Any, Any, T]]
     ) -> T | None:
         """Boilerplate to make update requests to api and handle errors."""
+        # TODO: replace the hand-rolled _token_error/_connect_error recovery
+        # with ConfigEntryAuthFailed (auth) + UpdateFailed (transport), letting
+        # the coordinator handle retry/availability (the modern HA pattern).
         try:
             if self._token_error:
                 _LOGGER.debug(
@@ -246,6 +248,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
             )
             response = await api_callable()
         except TimeoutError:
+            self._cycle_failed = True
             if not self._connect_error:
                 self._connect_error = True
                 _LOGGER.exception(
@@ -253,6 +256,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
                 )
             return None
         except TokenError as exc:
+            self._cycle_failed = True
             self._token_error = True
             if not self._connect_error:
                 self._connect_error = True
@@ -263,6 +267,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
                 )
             return None
         except NonZeroResponse:
+            self._cycle_failed = True
             if not self._connect_error:
                 self._connect_error = True
                 _LOGGER.exception(
@@ -273,6 +278,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
             # Bubble up to Home Assistant to pause polling and trigger re-auth
             raise
         except Exception:  # pylint: disable=broad-except  # noqa: BLE001
+            self._cycle_failed = True
             if not self._connect_error:
                 self._connect_error = True
             _LOGGER.exception(
@@ -327,7 +333,6 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
 
             alias = dev_info.get("alias", "").strip()
             name = dev_info.get("name", "").strip()
-            # Skip if both alias and name are empty
             if not alias and not name:
                 continue
 
@@ -342,8 +347,10 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         ifaces = await self._update_platform(self._api.wifi_ifaces_get)
         if not ifaces:
             return
-        for name, iface in ifaces.items():
-            self._wifi_ifaces[name] = WifiInterface(
+        # Rebuild the mapping each poll so an interface that disappears from the
+        # router doesn't linger in the snapshot.
+        self._wifi_ifaces = {
+            name: WifiInterface(
                 name=name,
                 enabled=iface.get("enabled", False),
                 ssid=iface.get("ssid", ""),
@@ -351,6 +358,8 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
                 hidden=iface.get("hidden", False),
                 encryption=iface.get("encryption", "UNKNOWN"),
             )
+            for name, iface in ifaces.items()
+        }
 
     async def update_tailscale_state(self) -> None:
         """Make a call to the API to get the tailscale state."""
@@ -380,49 +389,39 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         """Make call to the API to get the wireguard client state."""
         response = await self._update_platform(self._api.wireguard_client_list)
         if not response:
+            # No clients
+            self._wireguard_clients = {}
+            self._wireguard_connections = []
             return
-        for config in response:
-            self._wireguard_clients[config["peer_id"]] = WireGuardClient(
+        clients = {
+            config["peer_id"]: WireGuardClient(
                 name=config["name"],
                 connected=False,
                 group_id=config["group_id"],
                 peer_id=config["peer_id"],
                 tunnel_id=config.get("tunnel_id", None),
             )
+            for config in response
+        }
+        connections: list[WireGuardClient] = []
 
-        if len(self._wireguard_clients) == 0:
-            _LOGGER.debug("No wireguard clients, there is nothing to update")
-            return
-
-        # update whether the currently selected WG client is connected
-        response = await self._update_platform(self._api.wireguard_client_state)
-        if not response:
-            return
-        # 0 is disconnted, 1 is connected, 2 is connecting
-        self._wireguard_connections = []
-        for config in response:
+        states = await self._update_platform(self._api.wireguard_client_state)
+        for config in states or []:
             # OpenVPN configs are sometimes returned leading to errors.
             if config.get("type") != "wireguard":
                 continue
-            # if config["enabled"] is false then status does not exist
-            connected: bool = config.get("status", 0) != 0
+            client = clients.get(config["peer_id"])
+            if client is None:
+                continue
+            client.tunnel_id = config.get("tunnel_id", None)
+            # 0 is disconnected, 1 is connected, 2 is connecting; if
+            # config["enabled"] is false then status does not exist.
+            client.connected = config.get("status", 0) != 0
+            if client.connected:
+                connections.append(client)
 
-            if self._wireguard_clients[config["peer_id"]]:
-                client: WireGuardClient = self._wireguard_clients[config["peer_id"]]
-                client.tunnel_id = config.get("tunnel_id", None)
-                client.connected = connected
-                if connected:
-                    self._wireguard_connections.append(client)
-
-    def update_options(self, new_options: dict) -> bool:
-        """Update options. Returns True if a reload is required."""
-        req_reload = False
-        self._options.update(new_options)
-        return req_reload
-
-    # ------------------------------------------------------------------
-    # Identity properties consumed by entities
-    # ------------------------------------------------------------------
+        self._wireguard_clients = clients
+        self._wireguard_connections = connections
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -464,3 +463,6 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
     def device_name(self) -> str:
         """Return the router's display name (used for the device registry)."""
         return f"GL-iNet {self._model.upper()}"
+
+
+type GlinetConfigEntry = ConfigEntry[GLinetUpdateCoordinator]

--- a/custom_components/glinet/coordinator.py
+++ b/custom_components/glinet/coordinator.py
@@ -433,7 +433,7 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
                 (CONNECTION_NETWORK_MAC, format_mac(self.factory_mac)),
                 (CONNECTION_NETWORK_MAC, adjust_mac(self.factory_mac, 1)),
             },
-            name=self.name,
+            name=self.device_name,
             model=self.model or "GL-iNet Router",
             manufacturer="GL-iNet",
             configuration_url=self._host,
@@ -461,6 +461,6 @@ class GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData]):
         return self._model.upper()
 
     @property
-    def name(self) -> str:
-        """Return router name."""
+    def device_name(self) -> str:
+        """Return the router's display name (used for the device registry)."""
         return f"GL-iNet {self._model.upper()}"

--- a/custom_components/glinet/device_tracker.py
+++ b/custom_components/glinet/device_tracker.py
@@ -7,17 +7,15 @@ from typing import TYPE_CHECKING, Any
 
 from propcache.api import cached_property
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-    from .coordinator import GLinetUpdateCoordinator
+    from .coordinator import GlinetConfigEntry, GLinetUpdateCoordinator
     from .models import ClientDevInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,11 +25,11 @@ DEFAULT_DEVICE_NAME = "Unknown device"
 
 async def async_setup_entry(
     _: HomeAssistant,
-    entry: ConfigEntry,
+    entry: GlinetConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker for GLinet component."""
-    coordinator: GLinetUpdateCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
     tracked: set[str] = set()
 
     @callback

--- a/custom_components/glinet/device_tracker.py
+++ b/custom_components/glinet/device_tracker.py
@@ -84,6 +84,16 @@ class GLinetDevice(CoordinatorEntity["GLinetUpdateCoordinator"], ScannerEntity):
         return self._attr_hostname
 
     @property
+    def available(self) -> bool:
+        """Trackers stay available across transient poll failures.
+
+        Presence (home/away) is carried by is_connected + consider_home, so the
+        tracker should not flip to ``unavailable`` just because one poll failed
+        (which CoordinatorEntity.available would otherwise do).
+        """
+        return True
+
+    @property
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
         return self._device.is_connected

--- a/custom_components/glinet/device_tracker.py
+++ b/custom_components/glinet/device_tracker.py
@@ -9,14 +9,18 @@ from propcache.api import cached_property
 
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-    from .router import ClientDevInfo, GLinetRouter
+    from .coordinator import GLinetUpdateCoordinator
+    from .models import ClientDevInfo
+
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_DEVICE_NAME = "Unknown device"
 
@@ -27,55 +31,42 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker for GLinet component."""
-    router: GLinetRouter = entry.runtime_data
+    coordinator: GLinetUpdateCoordinator = entry.runtime_data
     tracked: set[str] = set()
 
     @callback
-    def update_router() -> None:
-        """Update the values of the router."""
-        add_entities(router, async_add_entities, tracked)
+    def add_new_entities() -> None:
+        """Add tracker entities for devices not yet seen."""
+        new_tracked = []
+        for mac, device in coordinator.data.devices.items():
+            if mac in tracked:
+                continue
+            new_tracked.append(GLinetDevice(coordinator, device))
+            tracked.add(mac)
+        if new_tracked:
+            async_add_entities(new_tracked)
 
-    update_router()
-
-
-_LOGGER = logging.getLogger(__name__)
-
-
-@callback
-def add_entities(
-    router: GLinetRouter,
-    async_add_entities: AddConfigEntryEntitiesCallback,
-    tracked: set[str],
-) -> None:
-    """Add all new tracker entities from the router."""
-    new_tracked = []
-    for mac, device in router.devices.items():
-        if mac in tracked:
-            continue
-
-        new_tracked.append(GLinetDevice(router, device))
-        tracked.add(mac)
-
-    if new_tracked:
-        async_add_entities(new_tracked)
+    # Discover new devices on every coordinator refresh (replaces the old
+    # signal_device_new dispatcher), and add the ones already known now.
+    entry.async_on_unload(coordinator.async_add_listener(add_new_entities))
+    add_new_entities()
 
 
-class GLinetDevice(ScannerEntity):
+class GLinetDevice(CoordinatorEntity["GLinetUpdateCoordinator"], ScannerEntity):
     """Representation of a GLinet tracked device."""
 
-    _attr_hostname: str
-    _attr_ip_address: str | None
-    _attr_mac_address: str
     _attr_source_type: SourceType = SourceType.ROUTER
 
-    def __init__(self, router: GLinetRouter, device: ClientDevInfo) -> None:
+    def __init__(
+        self, coordinator: GLinetUpdateCoordinator, device: ClientDevInfo
+    ) -> None:
         """Initialize a GLinet device."""
-        self._router: GLinetRouter = router
+        super().__init__(coordinator)
         self._device: ClientDevInfo = device
         self._icon = "mdi:radar"
-        self._attr_hostname: str = self._device.name or DEFAULT_DEVICE_NAME
-        self._attr_ip_address: str | None = self._device.ip_address
-        self._attr_mac_address: str = self._device.mac
+        self._attr_hostname: str = device.name or DEFAULT_DEVICE_NAME
+        self._attr_ip_address: str | None = device.ip_address
+        self._attr_mac_address: str = device.mac
 
     @property
     def unique_id(self) -> str:
@@ -105,9 +96,7 @@ class GLinetDevice(ScannerEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes."""
-
-        attrs = {}
-
+        attrs: dict[str, Any] = {}
         attrs["interface_type"] = str(self._device.interface_type)
         if self._device.last_activity:
             attrs["last_time_reachable"] = self._device.last_activity.isoformat(
@@ -129,24 +118,3 @@ class GLinetDevice(ScannerEntity):
     def mac_address(self) -> str | None:
         """Return the mac address of the device."""
         return self._attr_mac_address
-
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed."""
-        return True
-
-    @callback
-    def async_on_demand_update(self) -> None:
-        """Update state."""
-        self._device = self._router.devices[self._device.mac]
-        self.async_write_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        """Register state update callback."""
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                self._router.signal_device_update,
-                self.async_on_demand_update,
-            )
-        )

--- a/custom_components/glinet/models.py
+++ b/custom_components/glinet/models.py
@@ -1,0 +1,121 @@
+"""Data models shared across the GL-iNet integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+from homeassistant.util import dt as dt_util
+
+
+class DeviceInterfaceType(StrEnum):
+    """Enum for the possible interface types reported by glipy."""
+
+    WIFI_24 = "2.4GHz"
+    WIFI_5 = "5GHz"
+    LAN = "LAN"
+    WIFI_24_GUEST = "2.4GHz Guest"
+    WIFI_5_GUEST = "5GHz Guest"
+    UNKNOWN = "Unknown"
+    DONGLE = "Dongle"
+    BYPASS_ROUTE = "Bypass Route"
+    UNKNOWN2 = "Unknown"
+    MLO = "MLO"
+    MLO_GUEST = "MLO Guest"
+    WIFI_6 = "6GHz"
+    WIFI_6_GUEST = "6GHz Guest"
+
+
+@dataclass
+class WireGuardClient:
+    """Class for keeping track of WireGuard Client Configs."""
+
+    name: str
+    connected: bool = field(compare=False)
+    group_id: int
+    peer_id: int
+    tunnel_id: int | None
+
+
+@dataclass
+class WifiInterface:
+    """Class for keeping track of Wifi Interfaces."""
+
+    name: str
+    enabled: bool
+    ssid: str
+    guest: bool
+    hidden: bool
+    encryption: str
+
+
+class ClientDevInfo:
+    """Representation of a device connected to the router."""
+
+    def __init__(self, mac: str, name: str | None = None) -> None:
+        """Initialize a connected device."""
+        self._mac: str = mac
+        self._name: str | None = name
+        self._ip_address: str | None = None
+        self._last_activity: datetime = dt_util.utcnow() - timedelta(days=1)
+        self._connected: bool = False
+        self._if_type: DeviceInterfaceType = DeviceInterfaceType.UNKNOWN
+
+    def update(self, dev_info: dict | None = None, consider_home: int = 0) -> None:
+        """Update connected device info."""
+        now: datetime = dt_util.utcnow()
+        if dev_info:
+            # Prefer the user-defined alias as a name
+            alias = dev_info.get("alias")
+            if alias and alias.strip():
+                self._name = alias
+            else:
+                # If no alias, fallback to auto-assigned name field
+                name = dev_info.get("name", "")
+                if name == "*" or not name.strip():
+                    self._name = self._mac.replace(":", "_")
+                else:
+                    self._name = name
+            self._ip_address = dev_info.get("ip")
+            self._last_activity = now
+            self._connected = dev_info.get("online", False)
+            self._if_type = list(DeviceInterfaceType)[
+                dev_info.get("type", 5)
+            ]  # TODO be more index safe
+        # a device might not actually be online but we want to consider it home
+        elif self._connected:
+            self._connected = (
+                now - self._last_activity
+            ).total_seconds() < consider_home
+            self._ip_address = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Return connected status."""
+        return self._connected
+
+    @property
+    def interface_type(self) -> DeviceInterfaceType:
+        """Return device interface type."""
+        return self._if_type
+
+    @property
+    def mac(self) -> str:
+        """Return device mac address."""
+        return self._mac
+
+    @property
+    def name(self) -> str | None:
+        """Return device name."""
+        return self._name
+
+    @property
+    def ip_address(self) -> str | None:
+        """Return device ip address."""
+        return self._ip_address
+
+    @property
+    def last_activity(self) -> datetime:
+        """Return device last activity."""
+        return self._last_activity

--- a/custom_components/glinet/models.py
+++ b/custom_components/glinet/models.py
@@ -5,26 +5,146 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import StrEnum
+from functools import cache
+import logging
 
 from homeassistant.util import dt as dt_util
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class DeviceInterfaceType(StrEnum):
-    """Enum for the possible interface types reported by glipy."""
+    """The interface a client is connected to the router through."""
 
     WIFI_24 = "2.4GHz"
     WIFI_5 = "5GHz"
-    LAN = "LAN"
+    WIFI_6 = "6GHz"
     WIFI_24_GUEST = "2.4GHz Guest"
     WIFI_5_GUEST = "5GHz Guest"
-    UNKNOWN = "Unknown"
-    DONGLE = "Dongle"
-    BYPASS_ROUTE = "Bypass Route"
-    UNKNOWN2 = "Unknown"
+    WIFI_6_GUEST = "6GHz Guest"
     MLO = "MLO"
     MLO_GUEST = "MLO Guest"
-    WIFI_6 = "6GHz"
-    WIFI_6_GUEST = "6GHz Guest"
+    LAN = "LAN"
+    DONGLE = "Dongle"
+    BYPASS_ROUTE = "Bypass Route"
+    UNKNOWN = "Unknown"
+
+
+# Maps the self-describing ``iface`` string the router reports per client to a
+# DeviceInterfaceType (lower-cased for case-insensitive matching). Resolving from
+# this first makes interface labelling resilient to firmware that renumbers the
+# integer ``type`` codes.
+_IFACE_MAP: dict[str, DeviceInterfaceType] = {
+    "2.4g": DeviceInterfaceType.WIFI_24,
+    "5g": DeviceInterfaceType.WIFI_5,
+    "6g": DeviceInterfaceType.WIFI_6,
+    "mlo": DeviceInterfaceType.MLO,
+    "cable": DeviceInterfaceType.LAN,
+    "wired": DeviceInterfaceType.LAN,
+    "lan": DeviceInterfaceType.LAN,
+}
+
+# Guest networks carry a "guest" qualifier on some firmware; the first matching
+# band token wins. "2.4" is checked before "5"/"6" so it isn't shadowed.
+_GUEST_TOKENS: tuple[tuple[str, DeviceInterfaceType], ...] = (
+    ("2.4", DeviceInterfaceType.WIFI_24_GUEST),
+    ("6", DeviceInterfaceType.WIFI_6_GUEST),
+    ("mlo", DeviceInterfaceType.MLO_GUEST),
+    ("5", DeviceInterfaceType.WIFI_5_GUEST),
+)
+
+# Fallback mapping from the legacy integer ``type`` code. Positions matter:
+# indices 5 and 8 are reserved/unknown slots on observed firmware. An explicit
+# tuple (not ``list(DeviceInterfaceType)``) keeps the mapping stable and
+# bounds-safe - the unbounded enum index previously crashed with an IndexError
+# on Wi-Fi 7 / MLO clients.
+_TYPE_INDEX: tuple[DeviceInterfaceType, ...] = (
+    DeviceInterfaceType.WIFI_24,  # 0
+    DeviceInterfaceType.WIFI_5,  # 1
+    DeviceInterfaceType.LAN,  # 2
+    DeviceInterfaceType.WIFI_24_GUEST,  # 3
+    DeviceInterfaceType.WIFI_5_GUEST,  # 4
+    DeviceInterfaceType.UNKNOWN,  # 5 (reserved)
+    DeviceInterfaceType.DONGLE,  # 6
+    DeviceInterfaceType.BYPASS_ROUTE,  # 7
+    DeviceInterfaceType.UNKNOWN,  # 8 (reserved)
+    DeviceInterfaceType.MLO,  # 9
+    DeviceInterfaceType.MLO_GUEST,  # 10
+    DeviceInterfaceType.WIFI_6,  # 11
+    DeviceInterfaceType.WIFI_6_GUEST,  # 12
+)
+
+
+def _interface_type_from_code(raw_type: object) -> DeviceInterfaceType:
+    """Resolve the legacy integer ``type`` code to an interface, never raising."""
+    index: int | None = None
+    if isinstance(raw_type, bool):
+        index = None  # bool is an int subclass but is never a real type code
+    elif isinstance(raw_type, int):
+        index = raw_type
+    elif isinstance(raw_type, str):
+        try:
+            index = int(raw_type)
+        except ValueError:
+            index = None
+    if index is not None and 0 <= index < len(_TYPE_INDEX):
+        return _TYPE_INDEX[index]
+    return DeviceInterfaceType.UNKNOWN
+
+
+@cache
+def _log_unrecognised_interface(
+    iface: str,
+    raw_type: str,
+    model: str,
+    firmware: str,
+    dev_info_fields: tuple[str, ...],
+) -> None:
+    """Warn once per distinct context so an unknown interface doesn't spam logs."""
+    _LOGGER.warning(
+        "Unrecognised device interface (iface=%s type=%s) on GL-iNet model %s "
+        "(firmware %s; dev_info fields=%s). Using Unknown - please open an issue "
+        "with this log so support can be added",
+        iface or "<none>",
+        raw_type,
+        model or "unknown",
+        firmware or "unknown",
+        dev_info_fields,
+    )
+
+
+def interface_type_from_client(
+    dev_info: dict, *, model: str = "", firmware: str = ""
+) -> DeviceInterfaceType:
+    """Best-effort interface resolution from a client's dev_info, never raising.
+
+    Prefers the human-readable ``iface`` string ("2.4G", "5G", "6G", "MLO",
+    "cable"), falling back to the legacy integer ``type`` code. Unrecognised
+    interfaces resolve to UNKNOWN (logged once) so a device is always tracked,
+    never dropped, regardless of how it is connected.
+    """
+    iface = str(dev_info.get("iface") or "").strip().lower()
+    if iface in _IFACE_MAP:
+        return _IFACE_MAP[iface]
+    if "guest" in iface:
+        for token, guest_type in _GUEST_TOKENS:
+            if token in iface:
+                return guest_type
+    if "mlo" in iface:
+        return DeviceInterfaceType.MLO
+
+    resolved = _interface_type_from_code(dev_info.get("type"))
+    if resolved is DeviceInterfaceType.UNKNOWN and (
+        dev_info.get("iface") or dev_info.get("type") is not None
+    ):
+        _log_unrecognised_interface(
+            iface,
+            str(dev_info.get("type")),
+            model,
+            firmware,
+            tuple(sorted(str(key) for key in dev_info)),
+        )
+    return resolved
 
 
 @dataclass
@@ -62,7 +182,14 @@ class ClientDevInfo:
         self._connected: bool = False
         self._if_type: DeviceInterfaceType = DeviceInterfaceType.UNKNOWN
 
-    def update(self, dev_info: dict | None = None, consider_home: int = 0) -> None:
+    def update(
+        self,
+        dev_info: dict | None = None,
+        consider_home: int = 0,
+        *,
+        model: str = "",
+        firmware: str = "",
+    ) -> None:
         """Update connected device info."""
         now: datetime = dt_util.utcnow()
         if dev_info:
@@ -80,9 +207,9 @@ class ClientDevInfo:
             self._ip_address = dev_info.get("ip")
             self._last_activity = now
             self._connected = dev_info.get("online", False)
-            self._if_type = list(DeviceInterfaceType)[
-                dev_info.get("type", 5)
-            ]  # TODO be more index safe
+            self._if_type = interface_type_from_client(
+                dev_info, model=model, firmware=firmware
+            )
         # a device might not actually be online but we want to consider it home
         elif self._connected:
             self._connected = (

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -185,7 +185,10 @@ async def async_setup_entry(
 
 def _derive_boot_time(seconds_uptime: float) -> datetime:
     """Derive the boot timestamp from the router's uptime counter."""
-    return dt_util.utcnow() - timedelta(seconds=seconds_uptime)
+    # dt_util.utcnow() is untyped (Any) under the stubs; pin it to datetime so
+    # the subtraction below is typed rather than returning Any.
+    now: datetime = dt_util.utcnow()
+    return now - timedelta(seconds=seconds_uptime)
 
 
 def _boot_time_changed(old: datetime | None, new: datetime) -> bool:

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -63,9 +63,10 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda system_status: (
-            (la := system_status.get("load_average")) and isinstance(la, list) and la[0]
-        )
-        or None,
+            la[0]
+            if isinstance(la := system_status.get("load_average"), list) and len(la) > 0
+            else None
+        ),
     ),
     SystemStatusEntityDescription(
         key="load_avg5",
@@ -76,12 +77,10 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda system_status: (
-            (la := system_status.get("load_average"))
-            and isinstance(la, list)
-            and len(la) > 1
-            and la[1]
-        )
-        or None,
+            la[1]
+            if isinstance(la := system_status.get("load_average"), list) and len(la) > 1
+            else None
+        ),
     ),
     SystemStatusEntityDescription(
         key="load_avg15",
@@ -92,12 +91,10 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda system_status: (
-            (la := system_status.get("load_average"))
-            and isinstance(la, list)
-            and len(la) > 2
-            and la[2]
-        )
-        or None,
+            la[2]
+            if isinstance(la := system_status.get("load_average"), list) and len(la) > 2
+            else None
+        ),
     ),
     SystemStatusEntityDescription(
         key="memory_use",
@@ -110,7 +107,11 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda system_status: (
             (memory_total := system_status.get("memory_total", 0)) > 0
-            and (memory_free := system_status.get("memory_free", 0)) >= 0
+            and (
+                memory_free := system_status.get("memory_free", 0)
+                + system_status.get("memory_buff_cache", 0)
+            )
+            >= 0
             and (mu := 100 * (1 - memory_free / memory_total))
             and isinstance(mu, float)
             and 0 <= mu <= 100
@@ -120,6 +121,12 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         extra_attributes_fn=lambda system_status: {
             "memory_total": system_status.get("memory_total"),
             "memory_free": system_status.get("memory_free"),
+            "memory_buff_cache": system_status.get("memory_buff_cache"),
+            "memory_available": system_status.get("memory_free", 0)
+            + system_status.get("memory_buff_cache", 0),
+            "memory_used": system_status.get("memory_total", 0)
+            - system_status.get("memory_free", 0)
+            - system_status.get("memory_buff_cache", 0),
         },
     ),
     SystemStatusEntityDescription(

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -19,11 +19,10 @@ from homeassistant.util import dt as dt_util
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import GLinetUpdateCoordinator
+    from .coordinator import GlinetConfigEntry, GLinetUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,12 +149,12 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
 
 
 async def async_setup_entry(
-    _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    _: HomeAssistant, entry: GlinetConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up sensors."""
     _LOGGER.debug("Setting up GL-iNet Sensors")
 
-    coordinator: GLinetUpdateCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
     sensors: list[SystemStatusSensor | SystemUptimeSensor] = [
         SystemStatusSensor(coordinator=coordinator, entity_description=description)
         for description in SYSTEM_SENSORS

--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -13,7 +13,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
-from homeassistant.util.dt import utcnow
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -22,9 +23,14 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .router import GLinetRouter
+    from .coordinator import GLinetUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# Minimum movement in the derived boot time before a new timestamp is committed
+# to state. Mirrors Home Assistant's UniFi integration, which uses the same
+# tolerance to stop derived uptime timestamps flapping on every poll.
+UPTIME_DEVIATION = timedelta(seconds=120)
 
 
 class SystemStatusEntityDescription(SensorEntityDescription, frozen_or_thawed=True):
@@ -149,15 +155,15 @@ async def async_setup_entry(
     """Set up sensors."""
     _LOGGER.debug("Setting up GL-iNet Sensors")
 
-    router: GLinetRouter = entry.runtime_data
+    coordinator: GLinetUpdateCoordinator = entry.runtime_data
     sensors: list[SystemStatusSensor | SystemUptimeSensor] = [
-        SystemStatusSensor(router=router, entity_description=description)
+        SystemStatusSensor(coordinator=coordinator, entity_description=description)
         for description in SYSTEM_SENSORS
     ]
     # Special case for uptime as it requires additional data processing
     sensors.append(
         SystemUptimeSensor(
-            router=router,
+            coordinator=coordinator,
             entity_description=SystemStatusEntityDescription(
                 key="uptime",
                 name="Uptime",
@@ -170,47 +176,55 @@ async def async_setup_entry(
         )
     )
 
-    for sensor in sensors:
-        if sensor.native_value is None:
-            sensors.remove(sensor)
+    # Only add sensors whose value is available on this device/model. Build a
+    # new list rather than mutating `sensors` while iterating it, which would
+    # skip elements and leave unavailable sensors in place.
+    available = [sensor for sensor in sensors if sensor.native_value is not None]
 
-    async_add_entities(sensors, True)
-
-
-def _uptime_calculation(seconds_uptime: float, last_value: datetime | None) -> datetime:
-    """Calculate uptime with deviation."""
-    delta_uptime: datetime = utcnow() - timedelta(seconds=seconds_uptime)
-
-    if not last_value or abs((delta_uptime - last_value).total_seconds()) > 15:
-        return delta_uptime
-
-    return last_value
+    async_add_entities(available)
 
 
-class GliSensorBase(SensorEntity):
+def _derive_boot_time(seconds_uptime: float) -> datetime:
+    """Derive the boot timestamp from the router's uptime counter."""
+    return dt_util.utcnow() - timedelta(seconds=seconds_uptime)
+
+
+def _boot_time_changed(old: datetime | None, new: datetime) -> bool:
+    """Return whether the boot time moved enough to warrant a state write.
+
+    Mirrors UniFi's ``async_uptime_value_changed_fn``: sub-tolerance fluctuation
+    from second-granularity uptime and poll jitter is ignored so the timestamp
+    stays stable between reboots.
+    """
+    return old is None or abs(new - old) > UPTIME_DEVIATION
+
+
+class GliSensorBase(CoordinatorEntity["GLinetUpdateCoordinator"], SensorEntity):
     """GL-iNet sensor base class."""
+
+    entity_description: SystemStatusEntityDescription
 
     def __init__(
         self,
-        router: GLinetRouter,
+        coordinator: GLinetUpdateCoordinator,
         entity_description: SystemStatusEntityDescription,
     ) -> None:
         """Initialize the sensor class."""
-        self.router = router
-        self.entity_description: SystemStatusEntityDescription = entity_description
-        self._attr_device_info = router.device_info
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique id of the switch."""
-        return f"glinet_sensor/{self.router.factory_mac}/system_{self.entity_description.key}"
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = (
+            f"glinet_sensor/{coordinator.factory_mac}/system_{entity_description.key}"
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self.entity_description.extra_attributes_fn is None:
             return None
-        return self.entity_description.extra_attributes_fn(self.router.system_status)
+        return self.entity_description.extra_attributes_fn(
+            self.coordinator.data.system_status
+        )
 
 
 class SystemStatusSensor(GliSensorBase):
@@ -219,18 +233,30 @@ class SystemStatusSensor(GliSensorBase):
     @property
     def native_value(self) -> int | float | None:
         """Return the native value of the sensor."""
-        return self.entity_description.value_fn(self.router.system_status)
+        return self.entity_description.value_fn(self.coordinator.data.system_status)
 
 
 class SystemUptimeSensor(GliSensorBase):
-    """GL-iNet system uptime sensor class."""
+    """GL-iNet system uptime sensor class.
 
-    _current_value: datetime | None = None
+    The router exposes uptime as a seconds counter, so the boot timestamp is
+    derived as ``now - uptime``. It is recomputed only when the coordinator
+    reports a fresh uptime value, and the committed value is held stable within
+    ``UPTIME_DEVIATION`` -- the same approach core uses for the UniFi integration.
+    """
+
+    _attr_native_value: datetime | None = None
+    _last_uptime: float | None = None
 
     @property
     def native_value(self) -> datetime | None:
-        """Return the native value of the sensor."""
-        self._current_value = _uptime_calculation(
-            self.router.system_status["uptime"], self._current_value
-        )
-        return self._current_value
+        """Return the cached boot timestamp, recomputing only on fresh data."""
+        uptime = self.coordinator.data.system_status.get("uptime")
+        if uptime is None:
+            return self._attr_native_value
+        if uptime != self._last_uptime:
+            self._last_uptime = uptime
+            candidate = _derive_boot_time(uptime)
+            if _boot_time_changed(self._attr_native_value, candidate):
+                self._attr_native_value = candidate
+        return self._attr_native_value

--- a/custom_components/glinet/strings.json
+++ b/custom_components/glinet/strings.json
@@ -16,6 +16,18 @@
           "password": "The password you use to login to your router's admin page, this is unlikely to be the same as your WiFi password",
           "consider_home": "Seconds to wait before deciding that a device is away"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with your GL-iNet router",
+        "description": "The stored credentials for your GL-iNet router were rejected. Enter the current password to reconnect.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "username": "This is always 'root' by default on GL-iNet devices",
+          "password": "The password you use to login to your router's admin page, this is unlikely to be the same as your WiFi password"
+        }
       }
     },
     "error": {
@@ -24,7 +36,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/custom_components/glinet/switch.py
+++ b/custom_components/glinet/switch.py
@@ -44,6 +44,11 @@ async def async_setup_entry(
 class GliSwitchBase(CoordinatorEntity["GLinetUpdateCoordinator"], SwitchEntity):
     """GL-inet switch base class."""
 
+    # Bind the concrete coordinator type so `self.coordinator.data` is typed as
+    # GLinetData rather than Any (the generic parameter isn't propagated to the
+    # attribute by the homeassistant stubs).
+    coordinator: GLinetUpdateCoordinator
+
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
 

--- a/custom_components/glinet/switch.py
+++ b/custom_components/glinet/switch.py
@@ -10,21 +10,20 @@ from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import GLinetUpdateCoordinator
+    from .coordinator import GlinetConfigEntry, GLinetUpdateCoordinator
     from .models import WifiInterface, WireGuardClient
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    _: HomeAssistant, entry: GlinetConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the GL-iNet switches."""
-    coordinator: GLinetUpdateCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
     data = coordinator.data
     switches: list[WifiApSwitch | WireGuardSwitch | TailscaleSwitch] = []
     if data.wireguard_clients:

--- a/custom_components/glinet/switch.py
+++ b/custom_components/glinet/switch.py
@@ -1,4 +1,4 @@
-"""Support for turning on and off Pi-hole system."""
+"""Switch platform for the GL-iNet integration."""
 
 from __future__ import annotations
 
@@ -7,14 +7,15 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
-from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .router import GLinetRouter, WifiInterface, WireGuardClient
+    from .coordinator import GLinetUpdateCoordinator
+    from .models import WifiInterface, WireGuardClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,56 +23,66 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     _: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Pi-hole switch."""
-    router: GLinetRouter = entry.runtime_data
+    """Set up the GL-iNet switches."""
+    coordinator: GLinetUpdateCoordinator = entry.runtime_data
+    data = coordinator.data
     switches: list[WifiApSwitch | WireGuardSwitch | TailscaleSwitch] = []
-    if router.wireguard_clients:
+    if data.wireguard_clients:
         # TODO detect all configured wireguard, openvpn, shadowsocks and
         # TOR clients & servers with router/vpn/status? and gen a switch for each
         switches = [
-            WireGuardSwitch(router, client)
-            for client in router.wireguard_clients.values()
+            WireGuardSwitch(coordinator, client)
+            for client in data.wireguard_clients.values()
         ]
-    if router.tailscale_configured:
-        switches.append(TailscaleSwitch(router))
-    for iface_name, iface in router.wifi_ifaces.items():
-        switches.append(WifiApSwitch(router, iface_name, iface))
+    if data.tailscale_config:
+        switches.append(TailscaleSwitch(coordinator))
+    for iface_name, iface in data.wifi_ifaces.items():
+        switches.append(WifiApSwitch(coordinator, iface_name, iface))
     if switches:
-        async_add_entities(switches, True)
+        async_add_entities(switches)
 
 
-class GliSwitchBase(SwitchEntity):
+class GliSwitchBase(CoordinatorEntity["GLinetUpdateCoordinator"], SwitchEntity):
     """GL-inet switch base class."""
 
-    def __init__(self, router: GLinetRouter) -> None:
-        """Initialize a GLinet device."""
-        self._router = router
-        self._attr_device_info = router.device_info
-        self._attr_is_on: bool | None
-
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
-    @property
-    def is_on(self) -> bool | None:
-        """Return if the service is on."""
-        return self._attr_is_on
-
-    @property
-    def entity_category(self) -> EntityCategory:
-        """A config entity."""
-        return EntityCategory.CONFIG
+    def __init__(self, coordinator: GLinetUpdateCoordinator) -> None:
+        """Initialize a GLinet switch."""
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
 
 
 class WifiApSwitch(GliSwitchBase):
     """A WiFi AccessPoint switch."""
 
     def __init__(
-        self, router: GLinetRouter, iface_name: str, iface: WifiInterface
+        self,
+        coordinator: GLinetUpdateCoordinator,
+        iface_name: str,
+        iface: WifiInterface,
     ) -> None:
         """Initialize a GLinet device."""
-        super().__init__(router)
+        super().__init__(coordinator)
         self._iface_name = iface_name
-        self._iface = iface
+        self._iface_fallback = iface
+        self._attr_unique_id = (
+            f"glinet_switch/{coordinator.factory_mac}/iface_{iface_name}"
+        )
+
+    @property
+    def _iface(self) -> WifiInterface:
+        """Return the current interface state from the coordinator."""
+        return (
+            self.coordinator.data.wifi_ifaces.get(self._iface_name)
+            or self._iface_fallback
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the AP is enabled."""
+        return self._iface.enabled
 
     @property
     def icon(self) -> str:
@@ -83,116 +94,61 @@ class WifiApSwitch(GliSwitchBase):
     @property
     def name(self) -> str:
         """Return the name of the switch."""
-        return self._iface.ssid if self._iface.ssid else self._iface.name
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique id of the switch."""
-        return f"glinet_switch/{self._router.factory_mac}/iface_{self._iface_name}"
+        return self._iface.ssid or self._iface.name
 
     @property
     def extra_state_attributes(self) -> dict[str, str | bool]:
         """Return the attributes."""
-        attrs: dict[str, str | bool] = {}
-        attrs["interface"] = self._iface.name
-        attrs["guest"] = self._iface.guest
-        attrs["ssid"] = self._iface.ssid
-        attrs["hidden"] = self._iface.hidden
-        attrs["encryption"] = self._iface.encryption
-        return attrs
+        iface = self._iface
+        return {
+            "interface": iface.name,
+            "guest": iface.guest,
+            "ssid": iface.ssid,
+            "hidden": iface.hidden,
+            "encryption": iface.encryption,
+        }
 
     async def async_turn_on(self, **_: Any) -> None:
         """Turn on the AP."""
         try:
             _LOGGER.debug("Enabling WiFi interface %s", self._iface_name)
-            await self._router.api.wifi_iface_set_enabled(self._iface_name, True)
+            await self.coordinator.api.wifi_iface_set_enabled(self._iface_name, True)
         except OSError:
-            _LOGGER.exception(
-                "Unable to enable WiFi interface %s",
-                self._iface_name,
-            )
+            _LOGGER.exception("Unable to enable WiFi interface %s", self._iface_name)
         else:
-            # be optimistic
-            self._attr_is_on = True
-            self.async_write_ha_state()
-
-            # fetch the state #TODO try block?
-            await self._router.update_wifi_ifaces_state()
-            await self.async_update()
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the AP."""
         try:
             _LOGGER.debug("Disabling WiFi interface %s", self._iface_name)
-            await self._router.api.wifi_iface_set_enabled(self._iface_name, False)
+            await self.coordinator.api.wifi_iface_set_enabled(self._iface_name, False)
         except OSError:
-            _LOGGER.exception(
-                "Unable to disable WiFi interface %s",
-                self._iface_name,
-            )
+            _LOGGER.exception("Unable to disable WiFi interface %s", self._iface_name)
         else:
-            # be optimistic
-            self._attr_is_on = False
-            self.async_write_ha_state()
-
-            # fetch the state #TODO try block?
-            await self._router.update_wifi_ifaces_state()
-            await self.async_update()
-
-    @callback
-    async def async_update(self) -> None:
-        """Update the switch state."""
-        _LOGGER.debug(
-            "Updating WiFi AP switch with stored state for %s",
-            self._iface_name,
-        )
-        self._iface = self._router.wifi_ifaces.get(self._iface_name) or self._iface
-        self._attr_is_on = self._iface.enabled
+            await self.coordinator.async_request_refresh()
 
 
 class TailscaleSwitch(GliSwitchBase):
     """A tailscale switch."""
 
-    _attr_icon = "mdi:vpn"  # TODO would be better to have MDI style icons for each of the VPN types
+    _attr_icon = "mdi:vpn"
+    _attr_name = "Tailscale"
+
+    def __init__(self, coordinator: GLinetUpdateCoordinator) -> None:
+        """Initialize the Tailscale switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"glinet_switch/{coordinator.factory_mac}/tailscale"
 
     @property
-    def name(self) -> str:
-        """Return the name of the switch."""
-        # TODO we could add the login_name here, but we lose access to that value when the connection drops
-        return "Tailscale"
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique id of the switch."""
-        return f"glinet_switch/{self._router.factory_mac}/tailscale"
-
-    async def async_turn_on(self, **_: Any) -> None:
-        """Turn on the service."""
-        try:
-            _LOGGER.debug("Enabling tailscale")
-            await self._router.api.tailscale_start()
-            # TODO since the state takes a while to change we may
-        except OSError:
-            _LOGGER.exception("Unable to enable tailscale connection")
-        else:
-            self._attr_is_on = True
-            self.async_write_ha_state()
-
-    async def async_turn_off(self, **_: Any) -> None:
-        """Turn off the service."""
-        try:
-            _LOGGER.debug("Enabling tailscale")
-            await self._router.api.tailscale_stop()
-        except OSError:
-            _LOGGER.exception("Unable to stop tailscale connection")
-        else:
-            self._attr_is_on = False
-            self.async_write_ha_state()
+    def is_on(self) -> bool | None:
+        """Return if tailscale is connected."""
+        return self.coordinator.data.tailscale_connection
 
     @property
     def lan_access(self) -> bool | None:
         """Whether the router exposes the LAN as a subnet."""
-        la = self._router.tailscale_config.get("lan_enabled")
+        la = self.coordinator.data.tailscale_config.get("lan_enabled")
         if la is not None:
             return bool(la)
         return None
@@ -200,36 +156,49 @@ class TailscaleSwitch(GliSwitchBase):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Enabled by default."""
-        return self._router.tailscale_configured
+        return bool(self.coordinator.data.tailscale_config)
 
     @property
     def entity_registry_visible_default(self) -> bool:
-        """Enabled by default."""
-        return self._router.tailscale_configured
+        """Visible by default."""
+        return bool(self.coordinator.data.tailscale_config)
 
-    @callback
-    async def async_update(self) -> None:
-        """Update the switch state. Only one tailscale connection can be configured so this is not expensive."""
-        _LOGGER.debug("Updating Tailscale switch state")
-        await self._router.update_tailscale_state()
-        self._attr_is_on = self._router.tailscale_connection
+    async def async_turn_on(self, **_: Any) -> None:
+        """Turn on the service."""
+        try:
+            _LOGGER.debug("Enabling tailscale")
+            await self.coordinator.api.tailscale_start()
+        except OSError:
+            _LOGGER.exception("Unable to enable tailscale connection")
+        else:
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **_: Any) -> None:
+        """Turn off the service."""
+        try:
+            _LOGGER.debug("Disabling tailscale")
+            await self.coordinator.api.tailscale_stop()
+        except OSError:
+            _LOGGER.exception("Unable to stop tailscale connection")
+        else:
+            await self.coordinator.async_request_refresh()
 
 
 class WireGuardSwitch(GliSwitchBase):
     """Representation of a VPN switch."""
 
-    # TODO make class, client/server/VPN type agnostic and appreciate >1 can be configured of each
-    # And also appreciates that some combinations of states are not permitted by Gl-inet
-    # such as can't have a server and a client active of the same VPN type, also can't have
-    # multiples of any one type etc etc
-    def __init__(self, router: GLinetRouter, client: WireGuardClient) -> None:
-        """Initialize a GLinet device."""
-        super().__init__(router)
-        self._client = client
-        self._attr_device_info = router.device_info
-        self._attr_is_on: bool = False
+    _attr_icon = "mdi:vpn"
 
-    _attr_icon = "mdi:vpn"  # TODO would be better to have MDI style icons for each of the VPN types
+    # TODO make class, client/server/VPN type agnostic and appreciate >1 can be configured of each
+    def __init__(
+        self, coordinator: GLinetUpdateCoordinator, client: WireGuardClient
+    ) -> None:
+        """Initialize a GLinet device."""
+        super().__init__(coordinator)
+        self._client = client
+        self._attr_unique_id = (
+            f"glinet_switch/{coordinator.factory_mac}/{client.name}/wireguard_client"
+        )
 
     @property
     def name(self) -> str:
@@ -237,53 +206,50 @@ class WireGuardSwitch(GliSwitchBase):
         return f"WG Client {self._client.name}"
 
     @property
-    def unique_id(self) -> str:
-        """Return the unique id of the switch."""
-        return f"glinet_switch/{self._router.factory_mac}/{self._client.name}/wireguard_client"
+    def _current(self) -> WireGuardClient:
+        """Return the current client state from the coordinator (by peer_id)."""
+        return self.coordinator.data.wireguard_clients.get(
+            self._client.peer_id, self._client
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether this WireGuard client is connected."""
+        return self._current.connected
 
     async def async_turn_on(self, **_: Any) -> None:
         """Turn on the service."""
+        data = self.coordinator.data
+        current = self._current
         try:
-            # TODO Verify that the API doesn't do this for us
+            # On older firmware only one client may be connected at a time, so
+            # stop any other active client first.
             if (
-                self._client.tunnel_id
-                is None  # This confirms we are using older firmware
-                and self._router.connected_wireguard_clients is not None
-                and self._client not in self._router.connected_wireguard_clients
+                current.tunnel_id is None
+                and data.wireguard_connections
+                and not any(
+                    c.peer_id == current.peer_id for c in data.wireguard_connections
+                )
             ):
-                for client in self._router.connected_wireguard_clients:
-                    await self._router.api.wireguard_client_stop(client.peer_id)
-                # TODO may need to introduce a delay here, or await confirmation of the stop
+                for client in data.wireguard_connections:
+                    await self.coordinator.api.wireguard_client_stop(client.peer_id)
 
-            await self._router.api.wireguard_client_start(
-                self._client.group_id, self._client.tunnel_id or self._client.peer_id
+            await self.coordinator.api.wireguard_client_start(
+                current.group_id, current.tunnel_id or current.peer_id
             )
         except OSError:
             _LOGGER.exception("Unable to enable WG client")
         else:
-            self._attr_is_on = True
-            self.async_write_ha_state()
-            await self._router.update_wireguard_client_state()
-            await self.async_update()
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the service."""
+        current = self._current
         try:
-            await self._router.api.wireguard_client_stop(
-                self._client.tunnel_id or self._client.peer_id
+            await self.coordinator.api.wireguard_client_stop(
+                current.tunnel_id or current.peer_id
             )
-            # TODO may need to introduce a delay here, or await confirmation of the stop
         except OSError:
             _LOGGER.exception("Unable to stop WG client")
         else:
-            # be optimistic
-            self._attr_is_on = False
-            self.async_write_ha_state()
-            await self._router.update_wireguard_client_state()
-            await self.async_update()
-
-    @callback
-    async def async_update(self) -> None:
-        """Update the switch state. A user may have many so don't call the API for each."""
-        _LOGGER.debug("Updating WG client switch state from stored info")
-        self._attr_is_on = self._client in (self._router.wireguard_connections or [])
+            await self.coordinator.async_request_refresh()

--- a/custom_components/glinet/translations/en.json
+++ b/custom_components/glinet/translations/en.json
@@ -16,6 +16,18 @@
           "password": "The password you use to login to your router's admin page, this is unlikely to be the same as your WiFi password",
           "consider_home": "Seconds to wait before deciding that a device is away"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with your GL-iNet router",
+        "description": "The stored credentials for your GL-iNet router were rejected. Enter the current password to reconnect.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "data_description": {
+          "username": "This is always 'root' by default on GL-iNet devices",
+          "password": "The password you use to login to your router's admin page, this is unlikely to be the same as your WiFi password"
+        }
       }
     },
     "error": {
@@ -24,7 +36,8 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
     }
   },
   "options": {


### PR DESCRIPTION
## Summary

Converts the integration's hand-rolled data layer (`GLinetRouter` + a manual
`async_track_time_interval` timer + ad-hoc dispatcher signals + per-entity
`async_update` + `should_poll`) to a single Home Assistant `DataUpdateCoordinator`.

**Draft for comment** — see "Status" below.

## Why

- The manual poll loop was decoupled from entity reads (root cause of the uptime
  sensor flapping in #148) and leaked its timer on reload.
- Coordinator gives one HA-owned refresh loop, a single immutable-style data
  snapshot consumed by `CoordinatorEntity`, automatic push-to-entities, proper
  lifecycle (`async_config_entry_first_refresh`), and standard error surfaces.

## What changed

- **New `coordinator.py`** — `GLinetUpdateCoordinator(DataUpdateCoordinator[GLinetData])`
  owns the gli4py client + device identity and builds a `GLinetData` snapshot
  each `SCAN_INTERVAL`. `_async_update_data` raises `UpdateFailed` when the
  router is unreachable and `ConfigEntryAuthFailed` on token failure.
- **New `models.py`** — shared data classes moved out of `router.py`.
- **`const.py`** — `SCAN_INTERVAL` moved here.
- **All platforms → `CoordinatorEntity`**, reading `coordinator.data`; dropped
  `should_poll`/`async_update`. Switch toggles call the API then
  `async_request_refresh()`. Device trackers discover new clients via a
  coordinator listener (replaces the `signal_device_new/update` dispatchers).
- **`router.py` removed.**

This refactor folds in the fixes from #148 (uptime stabilisation) and #149
(setup list-mutation), so it **supersedes both** — recommend merging #148/#149
first, then rebasing this on top.

## Intentional behaviour changes (feedback welcome)

- Entities now go **unavailable** when the router is unreachable (previously
  they served stale state). Device **trackers** deliberately stay available
  (presence is carried by `is_connected` + consider_home).
- Switch toggles refresh from the router instead of optimistic flips, so the UI
  may lag briefly if the router is slow to apply a change.

## Status

- Verified locally with `ruff` + `py_compile`. The HA test stack can't build on
  the author's Windows box, so automated tests run in CI.
- **Tests are in a stacked PR** (see the tests PR) to keep this diff focused.
  This PR should only be merged once that PR is green (its CI exercises this
  refactor + the suite together).
- Known follow-up surfaced in review: the config flow still lacks an
  `async_step_reauth`, so the `ConfigEntryAuthFailed` path can't complete a
  reauth yet (pre-existing gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update

Two follow-ups that belong with this refactor have been added on top:

- **`async_step_reauth`** — `_async_update_data` raises `ConfigEntryAuthFailed`,
  which drives Home Assistant's reauth flow, but the config flow had no reauth
  step, so an auth failure dead-ended with an `UnknownStep` error. Added a
  minimal reauth step that re-prompts for the password and refreshes the token.
- **Strict-typing fixes** — silenced the `no-any-return` errors mypy strict
  reports for the new entities (the stubs don't propagate the `CoordinatorEntity`
  generic to `self.coordinator`), which also surfaced and corrected the
  `wireguard_clients` key type (`dict[int, …]`, keyed by `peer_id`).

The stacked tests PR exercises both.


### Bugfixes folded in (relocated by this refactor)

- **Interface-type crash (supersedes #145).** `models.py` resolves a client's
  interface from the self-describing `iface` string ("2.4G"/"5G"/"6G"/"MLO"/
  "cable") first, then a bounds-checked integer `type` map, and drops the
  duplicate `UNKNOWN2` enum member — fixing the WiFi7/MLO `IndexError` for good
  and folding in the `iface`-string angle from #145's review. #145 patches
  `router.py`, which this PR removed, so the fix had to be re-applied here.
- **Load-average 0 (#152)** and **buffers/cache as free memory (#111)** ported
  into the new `sensor.py` value_fns.

All exercised by the stacked tests PR.
