### PR TITLE
Report load averages of 0 instead of going unavailable

### DIFF
--- a/custom_components/glinet/sensor.py
+++ b/custom_components/glinet/sensor.py
@@ -58,9 +58,10 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda system_status: (
-            (la := system_status.get("load_average")) and isinstance(la, list) and la[0]
-        )
-        or None,
+            la[0]
+            if isinstance(la := system_status.get("load_average"), list) and len(la) > 0
+            else None
+        ),
     ),
     SystemStatusEntityDescription(
         key="load_avg5",
@@ -71,12 +72,10 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda system_status: (
-            (la := system_status.get("load_average"))
-            and isinstance(la, list)
-            and len(la) > 1
-            and la[1]
-        )
-        or None,
+            la[1]
+            if isinstance(la := system_status.get("load_average"), list) and len(la) > 1
+            else None
+        ),
     ),
     SystemStatusEntityDescription(
         key="load_avg15",
@@ -87,12 +86,10 @@ SYSTEM_SENSORS: list[SystemStatusEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda system_status: (
-            (la := system_status.get("load_average"))
-            and isinstance(la, list)
-            and len(la) > 2
-            and la[2]
-        )
-        or None,
+            la[2]
+            if isinstance(la := system_status.get("load_average"), list) and len(la) > 2
+            else None
+        ),
     ),
     SystemStatusEntityDescription(
         key="memory_use",


### PR DESCRIPTION
## Problem

The load-average sensors' `value_fn` ended in `… and la[N]) or None`. When a load value is genuinely **`0`** — e.g. an idle router's load average — `and la[N]` evaluates to `0` (falsy), so `0 or None` returns `None` and the sensor goes **`unavailable`** instead of reporting `0`. All three load sensors (1m/5m/15m) share this.

## Fix

Return the indexed value directly when the list is well-formed, falling back to `None` only when the data is actually missing/malformed:

```python
value_fn=lambda system_status: (
    la[2]
    if isinstance(la := system_status.get("load_average"), list) and len(la) > 2
    else None
),
```

## Validation against real hardware (GL.iNet MT6000, firmware 4.9.0)

Tested in a Home Assistant dev instance connected to a live MT6000, captured at the same condition (an idle router reporting a `0` load average).

**Before** (this branch's base, `master`) — router's 15-minute load = `0`:
```
sensor.gl_inet_mt6000_load_avg_15m = unavailable      <-- bug
```

**After** (with this fix) — router fully idle, `router_get_status()` returned `load_average: [0, 0.02, 0]`:
```
sensor.gl_inet_mt6000_load_avg_1m  = 0                <-- reports 0 (was unavailable under the bug)
sensor.gl_inet_mt6000_load_avg_15m = 0                <-- reports 0 (was unavailable under the bug)
```

**Deterministic check on the exact failing input:**
```
load_average=[0.06, 0.02, 0]    -> OLD=None    NEW=0      <-- the fix
load_average=[0.05, 0.03, 0.01] -> OLD=0.01    NEW=0.01   <-- no regression
load_average=None               -> OLD=None    NEW=None   <-- still safe
load_average=[]                 -> OLD=None    NEW=None   <-- still safe
```

Pre-existing bug (present unchanged on `master`), independent of #150 — raising it on its own as discussed.
